### PR TITLE
add sentiment adapter demo script

### DIFF
--- a/src/agents/demos/run_sentiment_adapter_demo.py
+++ b/src/agents/demos/run_sentiment_adapter_demo.py
@@ -1,0 +1,22 @@
+"""
+Demo script for testing SentimentAgentAdapter locally.
+Not used in Dolphin production pipeline.
+"""
+
+from sentiment_agent import build_agent
+from sentiment_adapter import SentimentAgentAdapter
+
+
+if __name__ == "__main__":
+    agent = build_agent(
+        model_path="./sentiment_ft",
+        lexicon_path="lexicon_master_final.csv",
+        device="cpu",
+    )
+
+    adapter = SentimentAgentAdapter(agent)
+
+    text = "아 네네 또 레전드라구요 ㅋㅋ"
+    out = adapter.run(text)
+
+    print(out)


### PR DESCRIPTION
Added a demo script for testing SentimentAgentAdapter locally.

## ✅ 작업 내용
- SentimentAgent + SentimentAgentAdapter를 로컬에서 빠르게 검증할 수 있는 demo 스크립트 추가
- Adapter 단계에서 sentiment 결과를 causality용 type으로 합성하는 흐름을 예시로 제공
- 실제 Dolphin 파이프라인에는 포함되지 않는 테스트/설명용 코드

---

## 🔗 관련 이슈
- 없음 (demo / utility 목적)

---

## 💬 특이사항
- 본 스크립트는 `demos/` 하위에 위치한 로컬 실행용 예시 코드입니다.
- production pipeline에는 사용되지 않으며, adapter 동작 확인 및 팀 공유용으로 추가되었습니다.
