### PR TITLE
Test/spike sentiment

### DIFF
--- a/tests/test_spike_to_sentiment.py
+++ b/tests/test_spike_to_sentiment.py
@@ -6,6 +6,16 @@ def test_spike_to_sentiment_integration():
 
     state = {
         "trace_id": "test-trace",
+        "workflow_start_time": "2026-01-01T00:00:00Z",
+        "route1_decision": None,
+        "route2_decision": None,
+        "route3_decision": None,
+        "skipped": False,
+        "skip_reason": None,
+        "node_insights": {},
+        "error_logs": [],
+        "spike_analysis": None,
+        "sentiment_result": None,
         "spike_event": {
             "keyword": "테스트",
             "current_volume": 10,
@@ -14,23 +24,21 @@ def test_spike_to_sentiment_integration():
             "detected_at": "2026-01-01T00:00:00Z",
             "messages": [
                 {
+                    "id": "m1",
+                    "source_message_id": "sm1",
                     "text": "보이콧 해야 하는 거 아니냐",
                     "timestamp": "2026-01-01T00:00:00Z",
                     "source": "twitter",
                     "author_id": "user1",
                     "metrics": {"likes": 3, "retweets": 1, "replies": 0},
+                    "is_anonymized": False,
                     "detected_language": "ko",
                 }
             ],
         },
-        "spike_analysis": None,
-        "sentiment_result": None,
-        "node_insights": {},
-        "error_logs": [],
     }
 
     result = workflow.invoke(state)
 
-    assert "sentiment_result" in result
-    assert result["sentiment_result"] is not None
-
+    assert result.get("sentiment_result") is not None
+    assert result["node_insights"].get("sentiment")


### PR DESCRIPTION
📌 작업 내용

tests/test_spike_to_sentiment.py 추가

LangGraph compile_workflow()를 통해
spike → sentiment 노드 연결 검증 테스트 작성

sentiment_result 생성 여부 및 node_insights["sentiment"] 확인

🎯 목적

Kafka 이후 단계에서
spike 이벤트가 sentiment 노드까지 정상적으로 전달되는지 검증

노드 간 state 전달 및 라우팅 연결성 확인

전체 파이프라인 중 분석 단계 안정성 보강

🧪 테스트 범위

외부 인프라(Kafka 등) 제외

모델 로딩 및 sentiment 노드 실행 여부 확인

감정 정확도 검증은 범위에 포함하지 않음 (연결성 검증 목적)
