### PR TITLE
Add full analysis test for sentiment to causality

### DIFF
--- a/tests/test_sentiment_to_causality.py
+++ b/tests/test_sentiment_to_causality.py
@@ -1,0 +1,51 @@
+from src.dolpin_langgraph.nodes import router2_node, causality_node
+
+
+def test_sentiment_to_causality_full_analysis():
+    state = {
+        "trace_id": "t-causality",
+        "node_insights": {},
+        "error_logs": [],
+        "spike_event": {
+            "keyword": "테스트",
+            "messages": [
+                {
+                    "text": "불매해야 한다",
+                    "timestamp": "2026-01-01T00:00:00Z",
+                    "source": "twitter",
+                    "author_id": "u1",
+                    "metrics": {"likes": 3, "retweets": 1, "replies": 0},
+                    "detected_language": "ko",
+                }
+            ],
+        },
+        "spike_analysis": {
+            "is_significant": True,
+            "spike_nature": "negative",
+            "spike_rate": 3.2,
+            "actionability_score": 0.6,
+        },
+        "sentiment_result": {
+            "dominant_sentiment": "boycott",
+            "sentiment_distribution": {
+                "boycott": 0.3,
+                "fanwar": 0.0,
+                "support": 0.1,
+                "disappointment": 0.6,
+            },
+            "confidence": 0.7,
+            "sentiment_shift": "worsening",
+            "analyzed_count": 1,
+            "representative_messages": {"boycott": ["불매해야 한다"]},
+        },
+        "route2_decision": None,
+        "positive_viral_detected": None,
+        "causality_result": None,
+    }
+
+    state = router2_node(state)
+    assert state["route2_decision"] == "full_analysis"
+
+    state = causality_node(state)
+    assert state.get("causality_result") is not None
+    assert state["node_insights"].get("causality")


### PR DESCRIPTION
📌 작업 내용

full_analysis 경로에서 Sentiment 이후 Causality 노드가 정상적으로 실행되는지 검증하는 테스트 추가

Router2 분기 결과가 "full_analysis"로 설정되는지 확인

causality_result가 state에 생성되는지 확인

🎯 목적

actionability_score 기반 Router2 분기 로직이 정상 동작하는지 검증

full_analysis 경로에서 Causality 노드 연결이 깨지지 않았는지 CI에서 조기 감지

🧪 테스트 범위

분석 정확도 검증이 아닌 노드 간 라우팅 및 state 생성 여부 확인

외부 인프라 의존성 없음
