### PR TITLE
refactor: fix statistical issues in SpikeAnalyzerAgent

### DIFF
--- a/src/agents/spike_analyzer.py
+++ b/src/agents/spike_analyzer.py
@@ -202,11 +202,11 @@ class SpikeAnalyzerAgent:
     # ──────────────────────────────────────────────
     def analyze(self, event: SpikeEvent) -> SpikeAnalysisResult:
         # ── 기본값 정제 ──────────────────────────
-        baseline = max(int(event.get("baseline", 0) or 0), 10)
+        baseline = int(event.get("baseline", 0) or 0)
         current_volume = int(event.get("current_volume", 0) or 0)
         raw_spike_rate = float(event.get("spike_rate", 0.0) or 0.0)
-        if raw_spike_rate <= 0 and current_volume > 0:
-            raw_spike_rate = current_volume / baseline
+        if raw_spike_rate <= 0 and baseline > 0 and current_volume > 0:
+            raw_spike_rate = current_volume / max(baseline, 10)
         spike_rate = round(float(raw_spike_rate), 2)
 
         keyword = str(event.get("keyword", "unknown"))

--- a/src/agents/spike_analyzer.py
+++ b/src/agents/spike_analyzer.py
@@ -54,13 +54,13 @@ class SpikeAnalyzerAgent:
     # 통계 지표 계산 (Z-Score, Acceleration, EPS)
     # ──────────────────────────────────────────────
     def _calculate_metrics(self, current_vol: float, messages: List[Dict[str, Any]]) -> Dict[str, float]:
-        # Z-Score: 과거 데이터가 2개 이상일 때만 의미있음
-        if len(self.baseline_history) < 2:
+        # Z-Score: 최소 12개(1시간치) 이상일 때만 의미있음
+        if len(self.baseline_history) < 12:
             z_score = 0.0
         else:
             arr = np.array(list(self.baseline_history), dtype=float) # 최근 24시간 동안 5분 단위 언급량들
-            # (current_vol - 평균) / 표준편차
-            z_score = (current_vol - float(np.mean(arr))) / (float(np.std(arr)) + 1e-6)
+            # (current_vol - 평균) / 표본표준편차 (ddof=1)
+            z_score = (current_vol - float(np.mean(arr))) / (float(np.std(arr, ddof=1)) + 1e-6)
 
         # Acceleration: 최근 1분 EPS vs 5분 EPS 비교
         now = datetime.now(timezone.utc)
@@ -202,10 +202,10 @@ class SpikeAnalyzerAgent:
     # ──────────────────────────────────────────────
     def analyze(self, event: SpikeEvent) -> SpikeAnalysisResult:
         # ── 기본값 정제 ──────────────────────────
-        baseline = int(event.get("baseline", 0) or 0)
+        baseline = max(int(event.get("baseline", 0) or 0), 10)
         current_volume = int(event.get("current_volume", 0) or 0)
         raw_spike_rate = float(event.get("spike_rate", 0.0) or 0.0)
-        if raw_spike_rate <= 0 and baseline > 0 and current_volume > 0:
+        if raw_spike_rate <= 0 and current_volume > 0:
             raw_spike_rate = current_volume / baseline
         spike_rate = round(float(raw_spike_rate), 2)
 


### PR DESCRIPTION
## ✅ 작업 내용
- `SpikeAnalyzerAgent` Z-score 계산 시 모집단 표준편차(`ddof=0`) → 표본 표준편차(`ddof=1`)로 수정
- Z-score 계산 최소 baseline 데이터 수를 2개 → 12개(1시간치)로 상향
- 신규 아티스트/비활동기 대응을 위해 `baseline` 하한값 10 적용 (spike_rate 폭발 방지)

---

## 💬 특이사항
- 중간발표 Q&A에서 "Z-score 임계값 설정 근거와 통계적 타당성"에 대한 질문이 들어왔고, 이를 검토하는 과정에서 발견한 통계적 오류를 수정
- `ddof=0`은 표본이 적을수록 표준편차를 과소추정해 Z-score가 실제보다 높게 계산되는 문제가 있었음
- baseline 2개로 Z-score를 계산하는 건 통계적으로 의미가 없어 최소 기준을 1시간치 데이터(12개)로 올림
- 비활동기 아티스트처럼 baseline이 1~2건인 경우 언급량이 조금만 늘어도 spike_rate가 폭발적으로 나오는 엣지케이스 방어 처리 추가