### PR TITLE
fix: Kafka Consumer 안정성 개선

### DIFF
--- a/src/pipeline/kafka_consumer.py
+++ b/src/pipeline/kafka_consumer.py
@@ -26,7 +26,9 @@ class KafkaConsumer:
             'group.id': group_id,
             # replay 모드면 과거 메시지까지 모두 읽고, 실시간이면 최신부터 읽음
             'auto.offset.reset': 'earliest' if os.getenv('MODE') == 'REPLAY' else 'latest',
-            'enable.auto.commit': True,
+            # 수동 커밋으로 전환 → 처리 완료 후에만 offset 커밋 (at-least-once 보장)
+            # True일 경우 poll() 직후 offset이 커밋되어 LangGraph 처리 실패 시 메시지 유실
+            'enable.auto.commit': False,
         }
         self.consumer = Consumer(self.conf)
         self.topic = os.getenv('KAFKA_TOPIC')
@@ -101,9 +103,16 @@ class KafkaConsumer:
                     callback(validated_msg)
 
                 except Exception as e:
-                    # 검증 실패 시 DLQ 보관
-                    logger.error(f"❌ 데이터 검증 실패: {e}")
+                    # 검증/파이프라인 실패 시 DLQ 보관
+                    logger.error(f"❌ 처리 실패 (DLQ 저장): {e}")
                     self._handle_failure(raw_data, str(e))
+
+                finally:
+                    # 성공/실패 무관하게 커밋
+                    # - 성공: 정상 처리 완료 후 커밋
+                    # - 실패: DLQ에 저장됐으므로 커밋하여 무한 재시도 방지
+                    #   (스키마 오류나 LLM 실패는 재시도해도 계속 실패하므로 커밋이 올바른 선택)
+                    self.consumer.commit(message=msg)
         finally:
             self.consumer.close()
 
@@ -148,5 +157,6 @@ if __name__ == "__main__":
                 logger.info(f"📨 Slack 전송 결과: {sent}")
         except Exception as e:
             logger.error(f"❌ 파이프라인 실패: [{msg.keyword}] {e}")
+            raise  # consume()의 finally 블록이 DLQ 저장 + 커밋을 처리하도록 예외 전파
 
     consumer.consume(callback=process_data)

--- a/src/pipeline/kafka_consumer.py
+++ b/src/pipeline/kafka_consumer.py
@@ -29,6 +29,9 @@ class KafkaConsumer:
             # 수동 커밋으로 전환 → 처리 완료 후에만 offset 커밋 (at-least-once 보장)
             # True일 경우 poll() 직후 offset이 커밋되어 LangGraph 처리 실패 시 메시지 유실
             'enable.auto.commit': False,
+            # LangGraph 파이프라인 최대 180초 + 여유 60초
+            # 기본값(300초)과 겹치지 않지만 명시해 리밸런싱 트리거 조건을 코드에서 확인 가능하게 함
+            'max.poll.interval.ms': 300000,
         }
         self.consumer = Consumer(self.conf)
         self.topic = os.getenv('KAFKA_TOPIC')

--- a/src/pipeline/kafka_consumer.py
+++ b/src/pipeline/kafka_consumer.py
@@ -94,6 +94,7 @@ class KafkaConsumer:
 
                 raw_data = msg.value().decode('utf-8')
 
+                commit_eligible = False
                 try:
                     # 데이터 검증
                     data_dict = json.loads(raw_data)
@@ -104,18 +105,24 @@ class KafkaConsumer:
 
                     # 외부 함수로 메시지 넘김
                     callback(validated_msg)
+                    commit_eligible = True  # 정상 처리 완료
 
                 except Exception as e:
                     # 검증/파이프라인 실패 시 DLQ 보관
-                    logger.error(f"❌ 처리 실패 (DLQ 저장): {e}")
+                    logger.error(f"❌ 처리 실패 (DLQ 저장 시도): {e}")
                     self._handle_failure(raw_data, str(e))
+                    # _handle_failure가 성공해야만 True — 디스크 풀/권한 오류로 DLQ 저장이
+                    # 실패하면 False를 유지해 커밋하지 않음 → 메시지가 Kafka에 남아 재처리 가능
+                    commit_eligible = True  # DLQ 저장 성공
 
                 finally:
-                    # 성공/실패 무관하게 커밋
-                    # - 성공: 정상 처리 완료 후 커밋
-                    # - 실패: DLQ에 저장됐으므로 커밋하여 무한 재시도 방지
-                    #   (스키마 오류나 LLM 실패는 재시도해도 계속 실패하므로 커밋이 올바른 선택)
-                    self.consumer.commit(message=msg)
+                    if commit_eligible:
+                        # 정상 처리 완료 또는 DLQ 저장 성공 시에만 커밋
+                        self.consumer.commit(message=msg)
+                    else:
+                        # DLQ 저장도 실패한 경우 커밋하지 않음
+                        # → 메시지가 Kafka에 남아 재처리 기회 보존
+                        logger.warning("⚠️ DLQ 저장 실패 — 커밋 보류, 메시지 재처리 예정")
         finally:
             self._executor.shutdown(wait=True)
             self.consumer.close()

--- a/src/pipeline/kafka_consumer.py
+++ b/src/pipeline/kafka_consumer.py
@@ -34,6 +34,7 @@ class KafkaConsumer:
         self.topic = os.getenv('KAFKA_TOPIC')
         self.dlq_path = "failed_events_log.jsonl"
         self._graph = None  # compile_workflow lazy init
+        self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
 
     def _get_graph(self):
         """워크플로우 그래프 싱글톤 (최초 호출 시 한 번만 컴파일)"""
@@ -60,16 +61,9 @@ class KafkaConsumer:
 
         def _invoke():
             # legal_rag_node가 async이므로 별도 스레드에서 새 이벤트 루프로 실행
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                return loop.run_until_complete(graph.ainvoke(state))
-            finally:
-                loop.close()
+            return asyncio.run(graph.ainvoke(state))
 
-        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
-        future = executor.submit(_invoke)
-        executor.shutdown(wait=False)
+        future = self._executor.submit(_invoke)
         return future.result(timeout=180)
 
     # 메시지 소비하고 콜백으로 넘기는 메서드
@@ -114,6 +108,7 @@ class KafkaConsumer:
                     #   (스키마 오류나 LLM 실패는 재시도해도 계속 실패하므로 커밋이 올바른 선택)
                     self.consumer.commit(message=msg)
         finally:
+            self._executor.shutdown(wait=True)
             self.consumer.close()
 
     # 실패한 메시지 따로 저장

--- a/src/pipeline/kafka_consumer.py
+++ b/src/pipeline/kafka_consumer.py
@@ -64,7 +64,16 @@ class KafkaConsumer:
             return asyncio.run(graph.ainvoke(state))
 
         future = self._executor.submit(_invoke)
-        return future.result(timeout=180)
+        try:
+            return future.result(timeout=180)
+        except concurrent.futures.TimeoutError:
+            # 타임아웃 시 executor 교체
+            # stuck worker가 self._executor의 유일한 슬롯을 점유한 상태이므로,
+            # 교체하지 않으면 이후 모든 submit()이 큐 뒤에 쌓여 연쇄 타임아웃 발생
+            # → consumer 전체가 재시작 전까지 마비됨
+            logger.error("LangGraph 타임아웃 (180초) — executor 교체하여 다음 메시지 처리 보장")
+            self._executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+            raise
 
     # 메시지 소비하고 콜백으로 넘기는 메서드
     def consume(self, callback: Callable[[KafkaMessage], None]):


### PR DESCRIPTION
## ✅ 작업 내용

**1. 수동 커밋으로 전환 (at-least-once 보장)**
- `enable.auto.commit: True` → `False`로 변경
- 처리 결과에 따라 `commit_eligible` 플래그로 커밋 여부 결정
  - 정상 처리 완료 → 커밋
  - 검증/파이프라인 실패 → DLQ 저장 성공 후 커밋 (재시도해도 항상 실패하므로 커밋이 올바른 선택)
  - DLQ 저장도 실패 (디스크 풀 등) → 커밋 보류, 메시지를 Kafka에 남겨 재처리 기회 보존

**2. 파이프라인 실패 시 예외 전파**
- `process_data`의 except 블록에 `raise` 추가
- `raise` 없이 예외를 삼키면 `consume()`의 except에 도달하지 못해 DLQ 저장이 건너뛰어짐 → "처리 실패 + DLQ 없음 + 커밋됨" 상태의 조용한 데이터 유실 버그 수정

**3. ThreadPoolExecutor 재사용 + 타임아웃 안전 처리**
- 메시지마다 새 executor를 생성하던 방식 → `__init__`에서 `self._executor` 1회 생성 후 재사용
- `asyncio.run()`으로 교체하여 수동 이벤트 루프 생성/종료 코드 제거
- 180초 타임아웃 발생 시 stuck worker가 유일한 슬롯을 점유하지 않도록 executor 교체 후 예외 재전파
- `consume()` 종료 시 `self._executor.shutdown(wait=True)`로 스레드 정리

**4. max.poll.interval.ms 명시 설정**
- 기본값(300초)과 동일하지만 명시하여 "workflow 180초 + 여유" 관계를 코드에서 확인 가능하게 함
- 수동 커밋 전환 시 리밸런싱 경계가 어디인지 코드에서 바로 파악 가능

---

## 💬 특이사항

- `commit_eligible` 패턴을 쓰는 이유: `_handle_failure()` 자체가 디스크 풀·권한 오류로 throw할 경우, 처리도 안 됐고 DLQ에도 없는 메시지를 커밋하면 복구 불가능한 데이터 손실이 됨. DLQ 저장 성공을 확인한 후에만 커밋
- ThreadPoolExecutor를 1개만 유지하는 이유: Kafka consumer는 메시지를 순차 처리하므로 `max_workers=1`로 충분. 메시지마다 새로 생성하면 OS 스레드 생성 비용(1~10ms)이 누적되고 `shutdown(wait=False)` 사용 시 stuck 스레드 누수 위험이 있음
- 타임아웃 시 executor를 교체하는 이유: `max_workers=1` 환경에서 stuck worker가 슬롯을 점유한 채로 있으면 이후 `submit()` 호출이 모두 큐 뒤에 쌓여 연쇄 타임아웃으로 consumer 전체가 마비됨