### PR TITLE
feat: 중간발표 데모 대비 Slack 개선 및 Kafka 버퍼링 수정 

### DIFF
--- a/src/dolpin_langgraph/nodes.py
+++ b/src/dolpin_langgraph/nodes.py
@@ -770,11 +770,40 @@ def exec_brief_node(state: AnalysisState) -> AnalysisState:
             workflow_start = datetime.fromisoformat(workflow_start_raw.replace("Z", "+00:00"))
             duration = (datetime.now(workflow_start.tzinfo) - workflow_start).total_seconds()
 
+        # 룰 기반 요약 (fallback)
         spike_summary = _generate_spike_summary(state)
         sentiment_summary = _generate_sentiment_summary(state)
         legal_summary = _generate_legal_summary(state)
         action_summary = _generate_action_summary(state)
         opportunity_summary = _generate_opportunity_summary(state)
+
+        # LLM 내러티브 요약으로 덮어쓰기 (OPENAI_API_KEY 있을 때)
+        if os.getenv("OPENAI_API_KEY"):
+            try:
+                from openai import OpenAI
+                from src.prompt import build_exec_brief_prompt, parse_exec_brief_response
+
+                prompt = build_exec_brief_prompt(state)
+                client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+                response = client.chat.completions.create(
+                    model="gpt-4o-mini",
+                    messages=[
+                        {"role": "system", "content": "당신은 K-POP 팬덤 이슈 관리 전문 PR 전략 AI입니다."},
+                        {"role": "user", "content": prompt},
+                    ],
+                    temperature=0.5,
+                    max_tokens=800,
+                )
+                parsed = parse_exec_brief_response(response.choices[0].message.content)
+                if parsed.get("spike_summary"):
+                    spike_summary = parsed["spike_summary"]
+                if parsed.get("sentiment_summary"):
+                    sentiment_summary = parsed["sentiment_summary"]
+                if parsed.get("opportunity_summary"):
+                    opportunity_summary = parsed["opportunity_summary"]
+                logger.info("ExecBrief LLM 내러티브 생성 완료")
+            except Exception as e:
+                logger.warning(f"ExecBrief LLM 생성 실패, 룰 기반 사용: {e}")
 
         playbook = state.get("playbook") or {}
         playbook_status = "failed"
@@ -890,22 +919,102 @@ def _generate_spike_summary(state: AnalysisState) -> Optional[str]:
     spike = state.get("spike_analysis")
     if not spike:
         return None
-    warning = f", {spike['partial_data_warning']}" if spike.get("partial_data_warning") else ""
-    return (
-        f"{spike['spike_rate']}배 급등, "
-        f"{spike['spike_type']} 타입, "
-        f"{'Breakout 포함' if spike['viral_indicators']['has_breakout'] else '일반 급등'}"
-        f"{warning}"
-    )
+
+    spike_rate = spike.get("spike_rate", 0)
+    spike_type = spike.get("spike_type", "unknown")
+    spike_nature = spike.get("spike_nature", "neutral")
+    confidence = spike.get("confidence", 0.0)
+    actionability = spike.get("actionability_score", 0.0)
+    viral = spike.get("viral_indicators", {})
+    has_breakout = viral.get("has_breakout", False)
+    is_trending = viral.get("is_trending", False)
+    cross_platform = viral.get("cross_platform", [])
+    international_reach = viral.get("international_reach", 0.0)
+
+    lines = [
+        f"*{spike_rate}배* 급등 감지 — {spike_type} 유형, 성격: {spike_nature}"
+    ]
+
+    status_parts = []
+    if has_breakout:
+        status_parts.append("Breakout 급등 (바이럴 확산 중)")
+    elif is_trending:
+        status_parts.append("트렌딩 진입")
+    else:
+        status_parts.append("일반 급등")
+
+    if cross_platform:
+        status_parts.append(f"멀티플랫폼 확산: {', '.join(cross_platform[:3])}")
+    if international_reach >= 0.3:
+        status_parts.append(f"해외 도달률 {international_reach*100:.0f}%")
+
+    lines.append(" | ".join(status_parts))
+
+    # 신뢰도 60% 이상일 때만 표시
+    if confidence >= 0.6:
+        lines.append(f"분석 신뢰도: {confidence*100:.0f}% | 대응 필요도: {actionability*10:.1f}/10")
+    else:
+        lines.append(f"대응 필요도: {actionability*10:.1f}/10")
+
+    warning = spike.get("partial_data_warning")
+    if warning:
+        lines.append(f"_⚠ {warning}_")
+
+    return "\n".join(lines)
 
 
 def _generate_sentiment_summary(state: AnalysisState) -> Optional[str]:
     sentiment = state.get("sentiment_result")
     if not sentiment:
         return None
-    dist = sentiment["sentiment_distribution"]
-    dominant = sentiment["dominant_sentiment"]
-    return f"{dominant} {dist[dominant]*100:.0f}%, 분석 {sentiment['analyzed_count']}건"
+
+    dist = sentiment.get("sentiment_distribution", {})
+    dominant = sentiment.get("dominant_sentiment", "unknown")
+    confidence = sentiment.get("confidence", 0.0)
+    analyzed_count = sentiment.get("analyzed_count", 0)
+    sentiment_shift = sentiment.get("sentiment_shift", "stable")
+
+    dominant_pct = dist.get(dominant, 0) * 100
+
+    label_map = {
+        "support": "응원/지지",
+        "excitement": "흥분/기대",
+        "meme": "밈/유머",
+        "concern": "우려",
+        "criticism": "비판",
+        "anger": "분노",
+        "disappointment": "실망",
+        "fanwar": "팬워",
+        "neutral": "중립",
+    }
+    shift_map = {
+        "worsening": "부정 방향으로 변화 중",
+        "improving": "긍정 방향으로 개선 중",
+        "stable": "안정적",
+    }
+
+    lines = [
+        f"주요 반응: *{label_map.get(dominant, dominant)}* ({dominant_pct:.0f}%) — {analyzed_count:,}건 분석"
+    ]
+
+    # 상위 3개 감정 분포 표시
+    top_sentiments = sorted(
+        [(k, v) for k, v in dist.items() if v > 0.05],
+        key=lambda x: x[1],
+        reverse=True
+    )[:3]
+    if top_sentiments:
+        dist_parts = [f"{label_map.get(k, k)} {v*100:.0f}%" for k, v in top_sentiments]
+        lines.append("분포: " + " | ".join(dist_parts))
+
+    shift_label = shift_map.get(sentiment_shift, sentiment_shift)
+    # 신뢰도 60% 이상일 때만 표시
+    if confidence >= 0.6:
+        lines.append(f"트렌드: {shift_label} | 신뢰도: {confidence*100:.0f}%")
+    else:
+        lines.append(f"트렌드: {shift_label}")
+
+    return "\n".join(lines)
 
 
 def _generate_legal_summary(state: AnalysisState) -> str:
@@ -931,8 +1040,31 @@ def _generate_opportunity_summary(state: AnalysisState) -> Optional[str]:
     spike = state.get("spike_analysis") or {}
     if spike.get("spike_nature") != "positive":
         return None
+
     playbook = state.get("playbook") or {}
     opportunities = playbook.get("key_opportunities", [])
-    if not opportunities:
+    amplification = state.get("amplification_summary") or {}
+    causality = state.get("causality_result") or {}
+
+    if not opportunities and not amplification:
         return None
-    return ", ".join(opportunities[:2])
+
+    lines = []
+
+    if opportunities:
+        opp_text = " / ".join(opportunities[:3])
+        lines.append(f"기회 요인: {opp_text}")
+
+    hub_accounts = amplification.get("hub_accounts") or causality.get("hub_accounts") or []
+    if hub_accounts:
+        lines.append(f"활용 가능한 허브 계정: {len(hub_accounts)}개 (확산 거점)")
+
+    platforms = amplification.get("top_platforms", [])
+    if platforms:
+        lines.append(f"핵심 플랫폼: {', '.join(platforms[:3])}")
+
+    rep_msgs = amplification.get("representative_messages", [])
+    if rep_msgs:
+        lines.append(f"대표 팬 반응 {len(rep_msgs)}건 — 공식 채널 재확산 검토 권장")
+
+    return "\n".join(lines) if lines else None

--- a/src/dolpin_langgraph/state.py
+++ b/src/dolpin_langgraph/state.py
@@ -7,14 +7,13 @@ DOLPIN 워크플로우의 전체 데이터 흐름을 정의합니다.
 """
 
 from typing import TypedDict, List, Dict, Any, Literal, Optional
-from datetime import datetime
 
 
 # ============================================================
 # 공통 타입 정의
 # ============================================================
 
-Source = Literal["twitter", "theqoo", "instiz", "google_trends"]
+Source = Literal["twitter", "instiz", "google_trends"]
 SpikeNature = Literal["positive", "negative", "mixed", "neutral"]
 DataCompleteness = Literal["confirmed", "partial", "mixed"]
 

--- a/src/integrations/slack/formatter.py
+++ b/src/integrations/slack/formatter.py
@@ -1,268 +1,500 @@
 # src/integrations/slack/formatter.py
 
 import os
-from typing import Any, Dict, List, Optional
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlparse
 
 from src.dolpin_langgraph.state import AnalysisState
 
-# Slack 메시지 길이 제한 (공식 권장값)
-MAX_SECTION_TEXT = 900
-MAX_ACTIONS = 3
+MAX_SECTION_TEXT = 2900
 DEFAULT_ALLOWED_LINK_HOSTS = {"dashboard.example.com"}
 
+_SOURCE_LABEL = {
+    "twitter":       "Twitter(X)",
+    "instiz":        "인스티즈",
+    "google_trends": "Google 트렌드",
+}
+_TIME_WINDOW_LABEL = {
+    "1h": "최근 1시간",
+    "3h": "최근 3시간",
+    "24h": "최근 24시간",
+}
+_SENTIMENT_LABEL = {
+    "support": "응원/지지",
+    "disappointment": "실망",
+    "boycott": "보이콧",
+    "meme": "밈/유머",
+    "fanwar": "팬워",
+    "neutral": "중립",
+}
+_SPIKE_NATURE_LABEL = {
+    "positive": "긍정 이슈",
+    "negative": "부정 이슈",
+    "mixed": "혼재 이슈",
+    "neutral": "중립 이슈",
+}
+_SPIKE_TYPE_LABEL = {
+    "organic": "자연 발생",
+    "media_driven": "미디어 주도",
+    "coordinated": "조직적 확산",
+}
+
+# 상황별 커뮤니케이션 DO/DON'T
+_COMM_GUIDE = {
+    "crisis": {
+        "do": ["감정 공감 우선", "명확하고 쉬운 표현", "빠른 초기 반응"],
+        "dont": ["법적·방어적 표현", "책임 회피성 언급", "기계적 반복 답변"],
+    },
+    "opportunity": {
+        "do": ["팬 참여 유도", "긍정 에너지 증폭", "공식 채널 활성화"],
+        "dont": ["과도한 상업적 메시지", "팬 감정 무시", "타이밍 놓치기"],
+    },
+    "monitoring": {
+        "do": ["상황 모니터링 지속", "팬 반응 수집", "준비 태세 유지"],
+        "dont": ["과잉 대응", "불필요한 언급", "상황 악화 조장"],
+    },
+}
+
+
+# ============================================================
+# 메인 포맷 함수
+# ============================================================
 
 def format_to_slack(state: AnalysisState) -> Dict[str, Any]:
     """
-    AnalysisState를 Slack Block Kit payload로 변환.
-
-    - 모든 텍스트는 mrkdwn escape 처리
-    - 외부 링크(dashboard/incident)는 allowlist 검증 후 clickable 링크로
+    AnalysisState → Slack Block Kit payload 변환.
+    데모 수준의 실무 레이아웃: 헤더 / 현재 상황 / 권장 전략 /
+    커뮤니케이션 가이드 / 성명 초안 / 확산 분석 / 푸터
     """
     blocks: List[Dict[str, Any]] = []
-    exec_brief = state.get("executive_brief") or {}
-    playbook = state.get("playbook") or {}
 
-    situation_raw = exec_brief.get("summary", "분석 중")
-    situation = _truncate_for_slack(str(situation_raw), 120)
-    severity_icon = _get_severity_icon(int(exec_brief.get("severity_score", 5)))
+    exec_brief   = state.get("executive_brief") or {}
+    playbook     = state.get("playbook") or {}
+    spike_event  = state.get("spike_event") or {}
+    spike        = state.get("spike_analysis") or {}
+    sentiment    = state.get("sentiment_result") or {}
+    keyword       = str(spike_event.get("keyword", "unknown"))
+    generated_at  = str(exec_brief.get("generated_at", ""))
+    severity      = int(exec_brief.get("severity_score", 5))
+    situation     = str(playbook.get("situation_type", "monitoring"))
 
-    blocks.append(
-        {
-            "type": "header",
-            "text": {
-                "type": "plain_text",
-                "text": f"{severity_icon} DOLPIN 이슈 리포트 | {situation}",
-            },
-        }
-    )
+    # ── 1. 헤더 ─────────────────────────────────────────────
+    severity_icon = _get_severity_icon(severity)
+    blocks.append({
+        "type": "header",
+        "text": {
+            "type": "plain_text",
+            "emoji": True,
+            "text": f"{severity_icon} DOLPIN 팬덤 이슈 대응 리포트",
+        },
+    })
 
-    blocks.append(
-        {
-            "type": "section",
-            "fields": [
-                {"type": "mrkdwn", "text": f"*우선순위:*\n{_format_priority(playbook.get('priority', 'unknown'))}"},
-                {"type": "mrkdwn", "text": f"*트렌드:*\n{_format_trend(exec_brief.get('trend_direction', 'stable'))}"},
-                {"type": "mrkdwn", "text": f"*이슈 성격:*\n{_format_polarity(exec_brief.get('issue_polarity', 'mixed'))}"},
-                {"type": "mrkdwn", "text": f"*심각도:*\n{int(exec_brief.get('severity_score', 5))}/10"},
-            ],
-        }
-    )
+    generated_display = _format_dt(generated_at)
+    blocks.append({
+        "type": "section",
+        "fields": [
+            {"type": "mrkdwn", "text": f"*아티스트:* {_esc(keyword)}"},
+            {"type": "mrkdwn", "text": f"*생성 시각:* {generated_display}"},
+        ],
+    })
     blocks.append({"type": "divider"})
 
-    _add_mrkdwn_section(blocks, "? 현재 상황", exec_brief.get("spike_summary"))
-    _add_mrkdwn_section(blocks, "? 팬 반응", exec_brief.get("sentiment_summary"))
+    # ── 2. 현재 상황 요약 ────────────────────────────────────
+    blocks.append({
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "*:pushpin: 현재 상황 요약*"},
+    })
 
-    recommended_actions = playbook.get("recommended_actions") or []
-    if recommended_actions:
-        actions_text = _format_actions(recommended_actions)
-        _add_mrkdwn_section(blocks, "? 권장 조치", actions_text, already_safe=True)
+    issue_type_text = _build_issue_type(spike, playbook)
+    reaction_text   = _build_reaction(sentiment, exec_brief)
+    blocks.append({
+        "type": "section",
+        "fields": [
+            {"type": "mrkdwn", "text": f"*이슈 유형*\n{issue_type_text}"},
+            {"type": "mrkdwn", "text": f"*주요 반응*\n{reaction_text}"},
+        ],
+    })
 
-    _add_mrkdwn_section(blocks, "? 확산 기회", exec_brief.get("opportunity_summary"))
-
-    legal_summary = exec_brief.get("legal_summary")
-    if legal_summary and legal_summary != "법률 검토 미수행":
-        _add_mrkdwn_section(blocks, "?? 법적 검토", legal_summary)
-
-    causality = state.get("causality_result") or {}
-    if causality:
-        trigger = _escape_mrkdwn_text(str(causality.get("trigger_source", "unknown")))
-        cascade = _escape_mrkdwn_text(str(causality.get("cascade_pattern", "unknown")))
-        _add_mrkdwn_section(blocks, "? 확산 경로", f"트리거: {trigger} | 패턴: {cascade}", already_safe=True)
-
-    user_message = exec_brief.get("user_message")
-    if user_message:
-        _add_mrkdwn_section(blocks, "?? 알림", user_message)
-
-    link_line = _build_link_line(exec_brief, state)
-    if link_line:
-        blocks.append(
-            {
-                "type": "context",
-                "elements": [{"type": "mrkdwn", "text": link_line}],
-            }
-        )
-
-    blocks.append({"type": "divider"})
-
-    generated_at = _escape_mrkdwn_text(str(exec_brief.get("generated_at", "")))
-    duration = float(exec_brief.get("analysis_duration_seconds", 0.0) or 0.0)
-    trace_id = str(state.get("trace_id", "unknown"))[:8]
-
-    blocks.append(
-        {
+    sources_text = _build_sources(spike_event)
+    if sources_text:
+        blocks.append({
             "type": "context",
-            "elements": [
-                {
-                    "type": "mrkdwn",
-                    "text": f"생성: {generated_at} | 분석 시간: {duration:.1f}초 | Trace: `{trace_id}`",
-                }
-            ],
-        }
-    )
+            "elements": [{"type": "mrkdwn", "text": f":round_pushpin: 분석 출처: {sources_text}"}],
+        })
 
-    return {
-        "blocks": blocks,
-        "text": f"DOLPIN 이슈 리포트 | {situation}",
-    }
-
-
-def _add_mrkdwn_section(
-    blocks: List[Dict[str, Any]],
-    title: str,
-    content: Optional[str],
-    *,
-    already_safe: bool = False,
-) -> None:
-    if not content:
-        return
-    body = content if already_safe else _escape_mrkdwn_text(str(content))
-    body = _truncate_for_slack(body, MAX_SECTION_TEXT)
-    blocks.append(
-        {
+    # 상세 분석 결과 (spike_summary / sentiment_summary — nodes.py에서 풍부하게 생성)
+    spike_summary = exec_brief.get("spike_summary")
+    if spike_summary:
+        blocks.append({
             "type": "section",
             "text": {
                 "type": "mrkdwn",
-                "text": f"*{title}*\n{body}",
+                "text": _trunc(str(spike_summary), MAX_SECTION_TEXT),
             },
-        }
+        })
+
+    sentiment_summary = exec_brief.get("sentiment_summary")
+    if sentiment_summary:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": _trunc(str(sentiment_summary), MAX_SECTION_TEXT),
+            },
+        })
+
+    # 팬 대표 반응 메시지
+    rep_messages_text = _build_representative_messages(sentiment)
+    if rep_messages_text:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*:thought_balloon: 팬 반응 탐지*\n{rep_messages_text}",
+            },
+        })
+
+    risk_line = _build_risk_line(severity, situation, spike)
+    if risk_line:
+        blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": risk_line}],
+        })
+
+    blocks.append({"type": "divider"})
+
+    # ── 3. 권장 대응 전략 ────────────────────────────────────
+    actions = playbook.get("recommended_actions") or []
+    if actions:
+        blocks.append({
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "*:dart: 권장 대응 전략*"},
+        })
+        for action in actions[:3]:
+            action_block = _format_action_block(action)
+            if action_block:
+                blocks.append({
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": action_block},
+                })
+        blocks.append({"type": "divider"})
+
+    # ── 4. 팬 커뮤니케이션 가이드 ───────────────────────────
+    do_text, dont_text = _build_comm_guide(situation)
+    blocks.append({
+        "type": "section",
+        "text": {"type": "mrkdwn", "text": "*:speech_balloon: 팬 커뮤니케이션 가이드*"},
+    })
+    blocks.append({
+        "type": "section",
+        "fields": [
+            {"type": "mrkdwn", "text": do_text},
+            {"type": "mrkdwn", "text": dont_text},
+        ],
+    })
+    blocks.append({"type": "divider"})
+
+    # ── 5. 공식 성명 초안 ────────────────────────────────────
+    draft = _extract_draft(actions)
+    if draft:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*:memo: 공식 성명 초안*\n{_esc(_trunc(draft, 800))}",
+            },
+        })
+        blocks.append({"type": "divider"})
+
+    # ── 6. 확산 기회 (긍정 이슈일 때) ───────────────────────
+    opportunity_summary = exec_brief.get("opportunity_summary")
+    if opportunity_summary:
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*:rocket: 확산 기회*\n{_trunc(str(opportunity_summary), MAX_SECTION_TEXT)}",
+            },
+        })
+
+    # ── 8. 법적 검토 ─────────────────────────────────────────
+    legal_summary = exec_brief.get("legal_summary")
+    if legal_summary and legal_summary != "법률 검토 미수행":
+        blocks.append({
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": f"*:scales: 법적 검토*\n{_esc(str(legal_summary))}",
+            },
+        })
+
+    # ── 9. 알림 (에러) ───────────────────────────────────────
+    user_message = exec_brief.get("user_message")
+    if user_message:
+        blocks.append({
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f":warning: {_esc(str(user_message))}"}],
+        })
+
+    # ── 10. 액션 버튼 ────────────────────────────────────────
+    trace_id = str(state.get("trace_id", "unknown"))[:8]
+    blocks.append({
+        "type": "actions",
+        "elements": [
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "emoji": True, "text": "✅ 확인 완료"},
+                "style": "primary",
+                "value": f"confirm_{trace_id}",
+                "action_id": "action_confirm",
+            },
+            {
+                "type": "button",
+                "text": {"type": "plain_text", "emoji": True, "text": "🔍 상세 분석 보기"},
+                "value": f"detail_{trace_id}",
+                "action_id": "action_detail",
+            },
+        ],
+    })
+
+    blocks.append({"type": "divider"})
+
+    # ── 11. 푸터 ─────────────────────────────────────────────
+    blocks.append({
+        "type": "context",
+        "elements": [{
+            "type": "mrkdwn",
+            "text": "본 리포트는 의사결정을 보조하기 위한 AI 기반 분석 결과이며, 최종 판단 및 책임은 담당자에게 있습니다.",
+        }],
+    })
+
+    duration = float(exec_brief.get("analysis_duration_seconds", 0.0) or 0.0)
+    blocks.append({
+        "type": "context",
+        "elements": [{
+            "type": "mrkdwn",
+            "text": (
+                f":bulb: Powered by DOLPIN | "
+                f"생성: {generated_display} | "
+                f"분석 시간: {duration:.1f}초 | "
+                f"Trace: `{trace_id}`"
+            ),
+        }],
+    })
+
+    return {
+        "blocks": blocks,
+        "text": f"DOLPIN 이슈 대응 리포트 | {keyword}",
+    }
+
+
+# ============================================================
+# 섹션별 빌더
+# ============================================================
+
+def _build_issue_type(spike: Dict, playbook: Dict) -> str:
+    """이슈 유형 필드 텍스트"""
+    spike_rate   = spike.get("spike_rate", 0)
+    spike_nature = spike.get("spike_nature", "neutral")
+    spike_type   = spike.get("spike_type", "organic")
+
+    nature_label = _SPIKE_NATURE_LABEL.get(spike_nature, spike_nature)
+    type_label   = _SPIKE_TYPE_LABEL.get(spike_type, spike_type)
+
+    return f"{spike_rate}배 급등 ({type_label})\n{nature_label}"
+
+
+def _build_reaction(sentiment: Dict, exec_brief: Dict) -> str:
+    """주요 반응 필드 텍스트 (dominant + 퍼센트)"""
+    dominant = sentiment.get("dominant_sentiment", "")
+    dist     = sentiment.get("sentiment_distribution", {})
+    polarity = exec_brief.get("issue_polarity", "mixed")
+
+    polarity_icon = {
+        "positive": ":large_green_circle:",
+        "negative": ":red_circle:",
+        "mixed":    ":large_yellow_circle:",
+    }.get(polarity, ":white_circle:")
+
+    label = _SENTIMENT_LABEL.get(dominant, dominant) if dominant else "분석 중"
+    pct   = dist.get(dominant, 0) * 100
+
+    return f"{polarity_icon} {label} {pct:.0f}%"
+
+
+def _build_sources(spike_event: Dict) -> str:
+    """실제 messages.source 필드 기반 분석 출처 텍스트"""
+    messages    = spike_event.get("messages") or []
+    seen        = dict.fromkeys(
+        msg.get("source", "") for msg in messages if msg.get("source")
     )
+    source_labels = [_SOURCE_LABEL.get(s, s) for s in seen if s]
+
+    if not source_labels:
+        return ""
+
+    time_window = spike_event.get("time_window", "")
+    time_label  = _TIME_WINDOW_LABEL.get(time_window, time_window)
+
+    sources_str = ", ".join(source_labels)
+    return f"{sources_str} ({time_label})" if time_label else sources_str
 
 
-def _escape_mrkdwn_text(text: str) -> str:
-    """Slack mrkdwn에서 안전하게 표시하기 위해 특수문자 escape"""
+def _build_risk_line(severity: int, situation: str, spike: Dict) -> str:
+    """위험도 / 기회 한 줄 요약"""
+    if situation == "crisis":
+        if severity >= 8:
+            return f":rotating_light: *위험도 {severity}/10* — 즉각 대응 필요"
+        elif severity >= 6:
+            return f":warning: *위험도 {severity}/10* — 빠른 확산 단계, 1차 공식 대응 권장"
+        else:
+            return f":warning: *위험도 {severity}/10* — 모니터링 강화 권장"
+    elif situation == "opportunity":
+        return f":rocket: *기회 점수 {severity}/10* — 긍정 바이럴 확산 중, 적극 활용 권장"
+    else:
+        return f":eyes: *모니터링 레벨 {severity}/10* — 지속 관찰 권장"
+
+
+def _format_action_block(action: Dict[str, Any]) -> str:
+    """액션 한 블록: 아이콘 + 이름(bold) + 설명"""
+    urgency = str(action.get("urgency", "medium"))
+    urgency_icon = {
+        "immediate": "🔴",
+        "urgent":    "🔴",
+        "high":      "🟠",
+        "medium":    "🟡",
+        "low":       "🟢",
+    }.get(urgency, "⚪")
+
+    action_type  = str(action.get("action", "unknown"))
+    description  = str(action.get("description", "")).strip()
+    action_name  = _translate_action_type(action_type)
+
+    lines = [f"{urgency_icon} *{_esc(action_name)}*"]
+    if description and description not in ("대응 전략", ""):
+        lines.append(_esc(_trunc(description, 400)))
+
+    rationale = str(action.get("rationale", "")).strip()
+    if rationale and len(rationale) > 10:
+        lines.append(f"_→ {_esc(_trunc(rationale, 200))}_")
+
+    return "\n".join(lines)
+
+
+def _build_comm_guide(situation: str) -> Tuple[str, str]:
+    """DO / DON'T 텍스트 튜플 반환 (Slack section fields 용)"""
+    guide = _COMM_GUIDE.get(situation, _COMM_GUIDE["monitoring"])
+    do_items   = "\n".join(f"• {item}" for item in guide["do"])
+    dont_items = "\n".join(f"• {item}" for item in guide["dont"])
+    return f"*DO*\n{do_items}", f"*DON'T*\n{dont_items}"
+
+
+def _extract_draft(actions: List[Dict[str, Any]]) -> Optional[str]:
+    """recommended_actions 중 draft 가 있는 첫 번째 항목 반환"""
+    for action in actions:
+        draft = action.get("draft")
+        if draft and len(str(draft).strip()) > 20:
+            return str(draft).strip()
+    return None
+
+
+def _build_representative_messages(sentiment: Dict) -> Optional[str]:
+    """sentiment_result의 representative_messages에서 팬 반응 샘플 추출"""
+    rep = sentiment.get("representative_messages") or {}
+    if not rep:
+        return None
+
+    lines = []
+    # dominant 감정 우선, 최대 3건
+    dominant = sentiment.get("dominant_sentiment", "")
+    order = [dominant] + [k for k in rep if k != dominant]
+
+    count = 0
+    for label in order:
+        messages = rep.get(label) or []
+        for msg in messages:
+            text = str(msg).strip()
+            if not text:
+                continue
+            lines.append(f"> {_esc(_trunc(text, 120))}")
+            count += 1
+            if count >= 3:
+                break
+        if count >= 3:
+            break
+
+    return "\n".join(lines) if lines else None
+
+
+
+# ============================================================
+# 공통 유틸
+# ============================================================
+
+def _esc(text: str) -> str:
+    """Slack mrkdwn 특수문자 escape"""
     escaped = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
     for mention in ("@here", "@channel", "@everyone"):
         escaped = escaped.replace(mention, f"`{mention}`")
     return escaped
 
 
-def _truncate_for_slack(text: str, max_len: int) -> str:
-    """텍스트 길이 제한 (Slack API 제한 대응)"""
+def _trunc(text: str, max_len: int) -> str:
     if len(text) <= max_len:
         return text
     return text[: max_len - 1] + "…"
 
 
-def _build_link_line(exec_brief: Dict[str, Any], state: AnalysisState) -> str:
-    """대시보드/인시던트 링크 라인 생성"""
-    links: List[str] = []
-    dashboard = _safe_link(exec_brief.get("dashboard_url"), "대시보드")
-    incident = _safe_link(exec_brief.get("incident_url"), "인시던트")
+def _format_dt(iso_str: str) -> str:
+    """ISO 8601 → 'YYYY-MM-DD HH:MM (KST)' 표시"""
+    if not iso_str:
+        return "알 수 없음"
+    try:
+        dt  = datetime.fromisoformat(iso_str.replace("Z", "+00:00"))
+        kst = dt + timedelta(hours=9)
+        return kst.strftime("%Y-%m-%d %H:%M")
+    except Exception:
+        return str(iso_str)[:16]
 
-    if dashboard:
-        links.append(dashboard)
-    if incident:
-        links.append(incident)
 
-    trace_id = str(state.get("trace_id", ""))
-    if trace_id:
-        links.append(f"Trace `{trace_id[:8]}`")
+def _get_severity_icon(severity_score: int) -> str:
+    if severity_score >= 8:
+        return "🔴"
+    if severity_score >= 6:
+        return "🟠"
+    if severity_score >= 4:
+        return "🟡"
+    return "🟢"
 
-    return " | ".join(links)
+
+def _translate_action_type(action_type: str) -> str:
+    action_map = {
+        "issue_statement":       "공식 입장문 발표",
+        "amplify_viral":         "긍정 바이럴 확산",
+        "legal_response":        "법률팀 검토 및 대응",
+        "monitor_only":          "팬 반응 모니터링",
+        "engage_influencers":    "허브 계정 협력",
+        "internal_review":       "내부 조사 및 재발 방지",
+        "prepare_communication": "팬 소통 준비",
+    }
+    return action_map.get(action_type, action_type)
 
 
 def _safe_link(url: Optional[str], label: str) -> str:
     """URL 검증 후 안전한 Slack 링크 생성 (allowlist 기반)"""
     if not url:
         return ""
-
     parsed = urlparse(str(url))
     if parsed.scheme != "https" or not parsed.netloc:
         return ""
 
     allowlist_raw = os.getenv("SLACK_LINK_ALLOWLIST", "")
-    allowed_hosts = {
-        host.strip().lower()
-        for host in allowlist_raw.split(",")
-        if host.strip()
-    }
+    allowed_hosts = {h.strip().lower() for h in allowlist_raw.split(",") if h.strip()}
     if not allowed_hosts:
         allowed_hosts = set(DEFAULT_ALLOWED_LINK_HOSTS)
 
-    host = parsed.netloc.lower()
-    if host not in allowed_hosts:
+    if parsed.netloc.lower() not in allowed_hosts:
         return ""
 
-    safe_label = _escape_mrkdwn_text(label)
-    return f"<{url}|{safe_label}>"
-
-
-def _get_severity_icon(severity_score: int) -> str:
-    if severity_score >= 8:
-        return ":red_circle:"
-    if severity_score >= 6:
-        return ":orange_circle:"
-    if severity_score >= 4:
-        return ":yellow_circle:"
-    return ":green_circle:"
-
-
-def _format_priority(priority: str) -> str:
-    priority_map = {
-        "urgent": ":red_circle: 긴급",
-        "high": ":orange_circle: 높음",
-        "medium": ":yellow_circle: 보통",
-        "low": ":green_circle: 낮음",
-    }
-    return priority_map.get(priority, "? 알 수 없음")
-
-
-def _format_trend(trend: str) -> str:
-    trend_map = {
-        "escalating": ":chart_with_upwards_trend: 악화",
-        "declining": ":chart_with_downwards_trend: 개선",
-        "stable": ":straight_ruler: 안정",
-    }
-    return trend_map.get(trend, ":straight_ruler: 안정")
-
-
-def _format_polarity(polarity: str) -> str:
-    polarity_map = {
-        "positive": ":large_green_circle: 긍정",
-        "negative": ":red_circle: 부정",
-        "mixed": ":large_yellow_circle: 혼재",
-    }
-    return polarity_map.get(polarity, ":large_yellow_circle: 혼재")
-
-
-def _format_actions(actions: List[Dict[str, Any]]) -> str:
-    """권장 조치 목록 포맷팅"""
-    if not actions:
-        return "권장 조치 없음"
-
-    lines: List[str] = []
-    for i, action in enumerate(actions[:MAX_ACTIONS], 1):
-        action_type = str(action.get("action", "unknown"))
-        description = str(action.get("description", "")).strip()
-        urgency = str(action.get("urgency", "medium"))
-
-        urgency_icon = {
-            "immediate": ":red_circle:",
-            "urgent": ":red_circle:",
-            "high": ":orange_circle:",
-            "medium": ":yellow_circle:",
-            "low": ":green_circle:",
-        }.get(urgency, ":white_circle:")
-
-        if description:
-            text = _escape_mrkdwn_text(_truncate_for_slack(description, 180))
-        else:
-            text = _escape_mrkdwn_text(_translate_action_type(action_type))
-        lines.append(f"{urgency_icon} {i}. {text}")
-
-    return "\n".join(lines)
-
-
-def _translate_action_type(action_type: str) -> str:
-    """Action type을 한글로 번역"""
-    action_map = {
-        "issue_statement": "공식 입장문 발표",
-        "amplify_viral": "긍정 바이럴 확산",
-        "legal_response": "법적 대응 준비",
-        "monitor_only": "모니터링 지속",
-        "engage_influencers": "허브 계정 협력",
-        "internal_review": "내부 조사 시작",
-        "prepare_communication": "커뮤니케이션 준비",
-    }
-    return action_map.get(action_type, action_type)
+    return f"<{url}|{_esc(label)}>"

--- a/src/pipeline/collector.py
+++ b/src/pipeline/collector.py
@@ -145,5 +145,16 @@ class UnifiedCollector:
         print(f"[{keyword}] 모든 수집 및 전송 프로세스 완료")
 
 if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        keyword = " ".join(sys.argv[1:]).strip()
+    else:
+        keyword = input("모니터링할 키워드를 입력하세요: ").strip()
+
+    if not keyword:
+        print("❌ 키워드를 입력해야 합니다.")
+        sys.exit(1)
+
+    print(f"\n🔍 [{keyword}] 수집 시작...\n")
     collector = UnifiedCollector()
-    collector.run("엔시티 위시")
+    collector.run(keyword)

--- a/src/pipeline/kafka_consumer.py
+++ b/src/pipeline/kafka_consumer.py
@@ -3,8 +3,9 @@ import concurrent.futures
 import json
 import logging
 import os
+from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Callable, Optional
+from typing import Callable, Dict, List
 
 from confluent_kafka import Consumer, KafkaError, KafkaException
 from dotenv import load_dotenv
@@ -13,6 +14,9 @@ from src.schemas.kafka_schema import KafkaMessage
 
 load_dotenv()
 logger = logging.getLogger(__name__)
+
+# 같은 키워드의 메시지를 묶어서 처리하기 위한 버퍼 윈도우 (초)
+BUFFER_WINDOW_SECONDS = float(os.getenv("BUFFER_WINDOW_SECONDS", "15"))
 
 
 class KafkaConsumer:
@@ -33,6 +37,10 @@ class KafkaConsumer:
         self.dlq_path = "failed_events_log.jsonl"
         self._graph = None  # compile_workflow lazy init
 
+        # 키워드별 메시지 버퍼
+        self._buffer: Dict[str, List[KafkaMessage]] = defaultdict(list)
+        self._buffer_opened_at: Dict[str, float] = {}  # 키워드별 버퍼 최초 수신 시각
+
     def _get_graph(self):
         """워크플로우 그래프 싱글톤 (최초 호출 시 한 번만 컴파일)"""
         if self._graph is None:
@@ -41,23 +49,14 @@ class KafkaConsumer:
             logger.info("LangGraph 워크플로우 컴파일 완료")
         return self._graph
 
-    def run_pipeline(self, msg: KafkaMessage) -> dict:
-        """
-        KafkaMessage → AnalysisState 변환 후 LangGraph 워크플로우 실행
+    def run_pipeline_batch(self, msgs: List[KafkaMessage]) -> dict:
+        """여러 KafkaMessage를 하나의 SpikeEvent로 묶어 파이프라인 실행"""
+        from src.pipeline.transformer import kafka_messages_to_state
 
-        Args:
-            msg: Kafka에서 수신한 검증된 메시지
-
-        Returns:
-            완료된 AnalysisState (executive_brief 포함)
-        """
-        from src.pipeline.transformer import kafka_message_to_state
-
-        state = kafka_message_to_state(msg)
+        state = kafka_messages_to_state(msgs)
         graph = self._get_graph()
 
         def _invoke():
-            # legal_rag_node가 async이므로 별도 스레드에서 새 이벤트 루프로 실행
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
             try:
@@ -70,14 +69,36 @@ class KafkaConsumer:
         executor.shutdown(wait=False)
         return future.result(timeout=180)
 
+    def _flush_buffer(self, keyword: str, callback: Callable[[List[KafkaMessage]], None]):
+        """키워드 버퍼를 플러시하고 콜백 호출"""
+        msgs = self._buffer.pop(keyword, [])
+        self._buffer_opened_at.pop(keyword, None)
+        if msgs:
+            logger.info(f"버퍼 플러시: [{keyword}] {len(msgs)}건 묶음 분석")
+            callback(msgs)
+
+    def _flush_expired_buffers(self, callback: Callable[[List[KafkaMessage]], None]):
+        """윈도우가 만료된 키워드 버퍼 자동 플러시"""
+        import time
+        now = time.monotonic()
+        expired = [
+            kw for kw, opened in self._buffer_opened_at.items()
+            if now - opened >= BUFFER_WINDOW_SECONDS
+        ]
+        for kw in expired:
+            self._flush_buffer(kw, callback)
+
     # 메시지 소비하고 콜백으로 넘기는 메서드
-    def consume(self, callback: Callable[[KafkaMessage], None]):
+    def consume(self, callback: Callable[[List[KafkaMessage]], None]):
+        import time
         try:
             self.consumer.subscribe([self.topic])
-            logger.info(f"Consumer 시작 (Mode: {os.getenv('MODE')})")
+            logger.info(f"Consumer 시작 (Mode: {os.getenv('MODE')}, 버퍼 윈도우: {BUFFER_WINDOW_SECONDS}초)")
 
             while True:
-                # 메시지 기다림, 없으면 루프
+                # 만료된 버퍼 주기적으로 플러시
+                self._flush_expired_buffers(callback)
+
                 msg = self.consumer.poll(1.0)
                 if msg is None:
                     continue
@@ -90,18 +111,22 @@ class KafkaConsumer:
                 raw_data = msg.value().decode('utf-8')
 
                 try:
-                    # 데이터 검증
                     data_dict = json.loads(raw_data)
                     validated_msg = KafkaMessage.model_validate(data_dict)
+                    keyword = validated_msg.keyword
 
-                    trace_id = getattr(validated_msg, 'message_id', 'no-id')
-                    logger.info(f"메시지 수신 성공 [{validated_msg.source}] ID: {trace_id}")
+                    logger.info(f"메시지 수신 [{validated_msg.source}] 키워드: {keyword}")
 
-                    # 외부 함수로 메시지 넘김
-                    callback(validated_msg)
+                    # 버퍼에 추가
+                    if keyword not in self._buffer_opened_at:
+                        self._buffer_opened_at[keyword] = time.monotonic()
+                    self._buffer[keyword].append(validated_msg)
+
+                    # trend 메시지 수신 시 즉시 플러시 (집계 데이터라 바로 처리)
+                    if validated_msg.type == "trend":
+                        self._flush_buffer(keyword, callback)
 
                 except Exception as e:
-                    # 검증 실패 시 DLQ 보관
                     logger.error(f"❌ 데이터 검증 실패: {e}")
                     self._handle_failure(raw_data, str(e))
         finally:
@@ -124,29 +149,22 @@ if __name__ == "__main__":
 
     consumer = KafkaConsumer()
 
-    def process_data(msg: KafkaMessage):
-        logger.info(f"--- 분석 시작 --- 키워드: {msg.keyword}")
+    def process_data(msgs: List[KafkaMessage]):
+        keyword = msgs[0].keyword
+        logger.info(f"--- 분석 시작 --- 키워드: {keyword} ({len(msgs)}건)")
         try:
-            result = consumer.run_pipeline(msg)
+            result = consumer.run_pipeline_batch(msgs)
             skipped = result.get("skipped", False)
             if skipped:
-                logger.info(f"⏭️  스킵됨: [{msg.keyword}] reason={result.get('skip_reason')}")
-                logger.info(f"spike_summary={result.get('spike_summary')}")
-                logger.info(f"executive_brief={result.get('executive_brief')}")
+                logger.info(f"⏭️  스킵됨: [{keyword}] reason={result.get('skip_reason')}")
             else:
                 from src.pipeline.result_store import save_result
-                from src.integrations.slack.formatter import format_to_slack
-                from src.integrations.slack.sender import send_to_slack
 
                 save_result(result)
 
-                slack_message = format_to_slack(result)
-                sent = send_to_slack(slack_message)
-                
                 brief = (result.get("executive_brief") or {}).get("summary", "N/A")
-                logger.info(f"✅ 분석 완료: [{msg.keyword}] {brief}")
-                logger.info(f"📨 Slack 전송 결과: {sent}")
+                logger.info(f"✅ 분석 완료: [{keyword}] {brief}")
         except Exception as e:
-            logger.error(f"❌ 파이프라인 실패: [{msg.keyword}] {e}")
+            logger.error(f"❌ 파이프라인 실패: [{keyword}] {e}")
 
     consumer.consume(callback=process_data)

--- a/src/pipeline/run_system_producer.py
+++ b/src/pipeline/run_system_producer.py
@@ -1,37 +1,105 @@
+"""
+DOLPIN 실시간 모니터링 데모 실행기
+
+사용법:
+  python -m src.pipeline.run_system_producer
+  python -m src.pipeline.run_system_producer 엔시티위시
+"""
+
+import sys
+import time
 from src.pipeline.kafka_producer import KafkaProducer
 from src.schemas.kafka_schema import KafkaMessage, ContentData
 
-producer = KafkaProducer()
+# ── 데모 데이터 (키워드별 시나리오) ─────────────────────────
 
-messages = [
-    "브랜드논란 때문에 불매하자는 반응이 늘고 있다",
-    "이번 브랜드논란 해명 필요하다",
-    "팬들 사이에서 boycott 얘기가 급격히 퍼진다",
-    "브랜드논란 관련 부정 반응이 집중되고 있다",
-    "이번 이슈는 이미지 타격이 크다",
-    "브랜드논란 관련 해명문이 필요해 보인다",
-    "팬덤에서 불매 해시태그가 확산 중이다",
-    "논란 대응이 늦어서 더 커지는 분위기다",
-    "브랜드논란 때문에 실망 반응이 많다",
-    "이번 건은 위기 대응이 필요하다",
-] 
+DEMO_DATA = {
+    "엔시티 위시": {
+        "source_mix": ["twitter", "twitter", "instiz", "twitter", "instiz",
+                       "twitter", "twitter", "instiz", "twitter", "google_trends"],
+        "messages": [
+            "엔시티 위시 콘서트 너무 좋았다ㅠㅠ 팀위시처하자",
+            "위시 선공개곡 진짜 미쳤다 계속 듣고있어 중독됨",
+            "엔시티 위시 사랑해",
+            "위시 콘서트 갔다온 후기 올림 퀄리티 진짜 기대 이상이었어",
+            "엔시티 위시 선공개 뮤직비디오 비주얼 미침 계속 돌려보는 중",
+            "위시 콘서트 직관한 사람 여기 있음? 나 완전 힐링하고 왔어",
+            "엔시티 위시 컴백 준비 많이 했나봐 이 퀄리티가 말이 되나",
+            "위시 선공개 스밍 열심히 하자",
+            "엔시티 위시 콘서트 앙코르 때 진짜 울뻔 했음 감동이야",
+            "위시 이번 컴백 역대급이다 선공개부터 이러면 정규는 어떨지 기대됨",
+        ],
+        "metrics": [
+            {"likes": 1240, "retweets": 380, "replies": 92},
+            {"likes": 870,  "retweets": 210, "replies": 54},
+            {"likes": 2100, "retweets": 560, "replies": 130},
+            {"likes": 430,  "retweets": 88,  "replies": 47},
+            {"likes": 3400, "retweets": 920, "replies": 201},
+            {"likes": 290,  "retweets": 61,  "replies": 33},
+            {"likes": 760,  "retweets": 195, "replies": 68},
+            {"likes": 510,  "retweets": 140, "replies": 29},
+            {"likes": 980,  "retweets": 244, "replies": 87},
+            {"likes": 1870, "retweets": 430, "replies": 114},
+        ],
+    },
+}
 
-for i, text in enumerate(messages, start=1):
-    msg = KafkaMessage(
-        type="post",
-        source="twitter",
-        keyword="브랜드논란",
-        content_data=ContentData(
-            text=text,
-            author_id=f"demo_user_{i}",
-            metrics={
-                "likes": 50 + i,
-                "retweets": 10 + (i % 7),
-                "replies": 3 + (i % 4),
-            },
-        ),
-    )
-    producer.send(msg)
+_DEFAULT_KEYWORD = "엔시티 위시"
 
-producer.flush()
-print("✅ 시스템용 Kafka 메시지 전송 완료")
+_SOURCE_LABEL = {
+    "twitter":       "Twitter(X)",
+    "instiz":        "인스티즈",
+    "google_trends": "Google 트렌드",
+}
+
+
+
+def main():
+    # ── 키워드 결정 ──────────────────────────────────────────
+    if len(sys.argv) > 1:
+        keyword = " ".join(sys.argv[1:]).strip()
+    else:
+        raw = input("\n모니터링할 키워드를 입력하세요: ").strip()
+        keyword = raw if raw else _DEFAULT_KEYWORD
+
+    data = DEMO_DATA.get(keyword, DEMO_DATA[_DEFAULT_KEYWORD])
+    messages  = data["messages"]
+    sources   = data["source_mix"]
+    metrics   = data["metrics"]
+
+    print(f"\n{'─'*52}")
+    print(f"  🐬 DOLPIN 실시간 모니터링")
+    print(f"  키워드: {keyword}")
+    print(f"{'─'*52}\n")
+
+    # ── 수집 단계 ─────────────────────────────────────────────
+    print("[ 1/3 ]  데이터 수집 중...\n")
+    time.sleep(0.4)
+
+    producer = KafkaProducer()
+
+    for i, (text, source, metric) in enumerate(zip(messages, sources, metrics), start=1):
+        source_label = _SOURCE_LABEL.get(source, source)
+        print(f"  [{source_label}] {text[:45]}{'...' if len(text) > 45 else ''}")
+        time.sleep(0.35)
+
+        msg = KafkaMessage(
+            type="post",
+            source=source,
+            keyword=keyword,
+            content_data=ContentData(
+                text=text,
+                author_id=f"user_{i:04d}",
+                metrics=metric,
+            ),
+        )
+        producer.send(msg)
+
+    producer.flush()
+
+    print(f"\n  총 {len(messages)}건 수집 완료\n")
+    print(f"{'─'*52}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline/transformer.py
+++ b/src/pipeline/transformer.py
@@ -7,7 +7,7 @@ Kafka에서 수신한 KafkaMessage를 LangGraph 워크플로우의
 
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from src.schemas.kafka_schema import KafkaMessage
 
@@ -87,6 +87,110 @@ def kafka_message_to_state(
         "spike_event": spike_event,
         "trace_id": msg.message_id,
         "workflow_start_time": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "sentiment_model_path": None,
+        "device": "cpu",
+        "lexicon_lookup_raw": None,
+        "route1_decision": None,
+        "route2_decision": None,
+        "route3_decision": None,
+        "positive_viral_detected": None,
+        "spike_analysis": None,
+        "lexicon_matches": None,
+        "sentiment_result": None,
+        "causality_result": None,
+        "legal_risk": None,
+        "amplification_summary": None,
+        "playbook": None,
+        "node_insights": {},
+        "executive_brief": None,
+        "error_logs": [],
+        "skipped": False,
+        "skip_reason": None,
+    }
+
+
+def kafka_messages_to_state(
+    msgs: List[KafkaMessage],
+    baseline_for_trend: int = 50,
+) -> Dict[str, Any]:
+    """
+    여러 KafkaMessage → 하나의 AnalysisState 변환 (키워드별 배치 처리용)
+
+    post 메시지들을 하나의 spike_event.messages로 합쳐서
+    충분한 텍스트 컨텍스트로 감정/스파이크 분석이 가능하게 한다.
+    trend 메시지가 섞여 있으면 spike_rate 계산에 활용한다.
+    """
+    if not msgs:
+        raise ValueError("msgs가 비어 있습니다.")
+
+    if len(msgs) == 1:
+        return kafka_message_to_state(msgs[0], baseline_for_trend)
+
+    keyword = msgs[0].keyword
+    now_iso = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    combined_messages: List[Dict[str, Any]] = []
+    trend_spike_rate: float = 0.0
+
+    for msg in msgs:
+        collected_at = (
+            msg.collected_at.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+            if msg.collected_at
+            else now_iso
+        )
+
+        if msg.type == "post" and msg.content_data:
+            combined_messages.append({
+                "id": str(uuid.uuid4()),
+                "source_message_id": msg.message_id,
+                "text": msg.content_data.text,
+                "timestamp": collected_at,
+                "source": msg.source,
+                "author_id": msg.content_data.author_id,
+                "metrics": msg.content_data.metrics,
+                "is_anonymized": False,
+                "detected_language": "ko",
+            })
+
+        elif msg.type == "trend" and msg.trend_data:
+            # trend 메시지: 검색어를 텍스트로 추가하고 spike_rate 계산에 활용
+            for q in msg.trend_data.rising_queries:
+                combined_messages.append({
+                    "id": str(uuid.uuid4()),
+                    "source_message_id": q.query,
+                    "text": q.query,
+                    "timestamp": collected_at,
+                    "source": msg.source,
+                    "detected_language": "ko",
+                })
+            rate = round(msg.trend_data.interest_score / baseline_for_trend, 2) if baseline_for_trend > 0 else 0.0
+            trend_spike_rate = max(trend_spike_rate, rate)
+
+    post_count = sum(1 for m in msgs if m.type == "post")
+    current_volume = post_count if post_count > 0 else int(trend_spike_rate * baseline_for_trend)
+    baseline = 1 if post_count > 0 else baseline_for_trend
+    # post 메시지가 있으면 SpikeAnalyzer가 current_volume/baseline으로 재계산하도록 0.0으로 세팅
+    # (trend_spike_rate를 그대로 넘기면 SpikeAnalyzer가 재계산하지 않아 not_significant 처리됨)
+    spike_rate = 0.0 if post_count > 0 else trend_spike_rate
+
+    # 대표 trace_id는 첫 번째 메시지 사용
+    trace_id = msgs[0].message_id
+
+    spike_event = {
+        "keyword": keyword,
+        "spike_rate": spike_rate,
+        "baseline": baseline,
+        "current_volume": current_volume,
+        "detected_at": now_iso,
+        "time_window": "1h",
+        "messages": combined_messages,
+        "raw_kafka_message_ids": [m.message_id for m in msgs],
+    }
+
+    return {
+        "spike_event": spike_event,
+        "trace_id": trace_id,
+        "workflow_start_time": now_iso,
         "sentiment_model_path": None,
         "device": "cpu",
         "lexicon_lookup_raw": None,

--- a/src/prompt.py
+++ b/src/prompt.py
@@ -95,6 +95,14 @@ def build_playbook_enhancement_prompt(
     
     # 프롬프트 조립
     prompt = f"""당신은 K-POP 팬덤 이슈 관리 및 PR 전략을 전문으로 하는 위기 관리 AI 어드바이저입니다.
+K-POP 팬덤 문화에 대한 깊은 이해를 바탕으로 실무에서 실제로 효과 있는 전략을 제시합니다.
+
+[K-POP 팬덤 문화 핵심 인사이트 — 반드시 반영]
+- 팬 아트·팬 콘텐츠에 아티스트가 직접 피드백하거나 소개하는 것은 절대 금지 — 다른 팬들의 질투와 역반응을 유발함
+- 긍정 바이럴 확산은 팬들이 자발 참여할 수 있는 트렌디한 챌린지 기획·촬영(릴스, 숏폼 포맷)이 가장 효과적
+- 허브 계정 대응은 단순 협력·출연 섭외가 아니라, 팬들이 오랫동안 원해온 자체 컨텐츠(멤버 자체 예능, 브이로그, 비하인드 시리즈 등)를 직접 제작하여 허브 계정이 자연스럽게 언급·확산하도록 유도하는 방식
+- 공식 소통은 장문 입장문보다 아티스트 본인의 짧고 진정성 있는 메시지(위버스·SNS 직접 소통)가 팬심에 더 효과적
+- 팬들이 가장 원하는 것: 아티스트의 직접 소통, 비하인드 콘텐츠, 멤버들이 직접 만드는 자체 제작 예능/브이로그
 
 [현재 상황]
 - 아티스트: {keyword}
@@ -112,8 +120,8 @@ def build_playbook_enhancement_prompt(
 
 1. **구체적 실행 방안** (2-3문장)
    - 무엇을, 어떻게, 누구를 대상으로 할 것인가
-   - 실무적으로 실행 가능한 구체적인 방법 제시
-   
+   - 위 K-POP 팬덤 인사이트를 반영한 실무적으로 실행 가능한 구체적인 방법 제시
+
 2. **예상 효과 및 근거** (2-3문장)
    - 왜 이 액션이 필요한가
    - 어떤 효과를 기대하는가
@@ -218,7 +226,109 @@ def parse_playbook_enhancement_response(
 
 
 # ============================================================
-# 추가될 프롬프트 
+# ExecBrief LLM 내러티브 생성 프롬프트
+# ============================================================
+
+def build_exec_brief_prompt(state: dict) -> str:
+    """
+    분석 결과 전체를 받아 Slack 리포트용 내러티브 요약을 생성하는 프롬프트.
+    spike_summary / sentiment_summary / opportunity_summary를 LLM이 자연어로 작성.
+    """
+    spike_event = state.get("spike_event") or {}
+    spike       = state.get("spike_analysis") or {}
+    sentiment   = state.get("sentiment_result") or {}
+    causality   = state.get("causality_result") or {}
+    playbook    = state.get("playbook") or {}
+
+    keyword       = spike_event.get("keyword", "미상")
+    spike_rate    = spike.get("spike_rate", 0)
+    spike_nature  = spike.get("spike_nature", "neutral")
+    spike_type    = spike.get("spike_type", "organic")
+    situation     = playbook.get("situation_type", "monitoring")
+
+    dominant      = sentiment.get("dominant_sentiment", "neutral")
+    dist          = sentiment.get("sentiment_distribution") or {}
+    analyzed      = sentiment.get("analyzed_count", 0)
+    confidence    = sentiment.get("confidence", 0)
+
+    # 대표 메시지 샘플 (최대 3건)
+    rep_msgs = sentiment.get("representative_messages") or {}
+    sample_lines = []
+    for msgs in rep_msgs.values():
+        for msg in (msgs or [])[:2]:
+            if msg:
+                sample_lines.append(f'- "{str(msg).strip()[:100]}"')
+            if len(sample_lines) >= 3:
+                break
+        if len(sample_lines) >= 3:
+            break
+    sample_text = "\n".join(sample_lines) if sample_lines else "샘플 없음"
+
+    # 확산 경로
+    trigger  = causality.get("trigger_source", "알 수 없음")
+    cascade  = causality.get("cascade_pattern", "알 수 없음")
+    hub_cnt  = len(causality.get("hub_accounts") or [])
+
+    situation_map = {
+        "crisis":      "부정 이슈 — 팬들의 비판·실망이 확산 중인 위기 상황",
+        "opportunity": "긍정 이슈 — 팬덤 확장 기회가 있는 바이럴 상황",
+        "monitoring":  "일반 모니터링 — 특별한 대응이 필요 없는 안정적 상황",
+    }
+    situation_desc = situation_map.get(situation, situation)
+
+    prompt = f"""당신은 K-POP 팬덤 이슈 관리를 전문으로 하는 PR 전략 AI입니다.
+아래 분석 데이터를 바탕으로 Slack 리포트에 들어갈 자연어 요약 3가지를 작성하세요.
+
+[분석 데이터]
+- 아티스트/키워드: {keyword}
+- 급등 규모: {spike_rate}배 ({spike_type} 유형, {spike_nature} 성격)
+- 상황 유형: {situation_desc}
+- 주요 팬 반응: {dominant} ({dist.get(dominant, 0)*100:.0f}%), 총 {analyzed}건 분석, 신뢰도 {confidence*100:.0f}%
+- 감정 분포: {", ".join(f"{k} {v*100:.0f}%" for k, v in dist.items() if v > 0.05)}
+- 확산 트리거: {trigger} / 패턴: {cascade} / 허브 계정: {hub_cnt}개
+- 팬 반응 샘플:
+{sample_text}
+
+[요청]
+아래 3가지를 각각 2~3문장의 한국어 존댓말로 작성하세요.
+데이터 수치를 자연스럽게 녹여서 실무자가 바로 이해할 수 있게 작성하세요.
+
+1. **현재 상황 요약** — 무슨 일이 일어나고 있는지, 얼마나 빠르게 확산되는지
+2. **팬 반응 요약** — 팬들이 어떤 감정으로 무슨 이야기를 하는지
+3. **확산 기회/위험** — 지금 상황에서 주목해야 할 점 (긍정이면 기회, 부정이면 위험)
+
+[출력 형식] 반드시 아래 마커를 지켜 출력하세요.
+---SPIKE_START---
+(현재 상황 요약 2~3문장)
+---SPIKE_END---
+---SENTIMENT_START---
+(팬 반응 요약 2~3문장)
+---SENTIMENT_END---
+---OPPORTUNITY_START---
+(확산 기회/위험 2~3문장)
+---OPPORTUNITY_END---
+"""
+    return prompt
+
+
+def parse_exec_brief_response(response_text: str) -> dict:
+    """ExecBrief LLM 응답 파싱 → spike/sentiment/opportunity 텍스트 추출"""
+    def _extract(text: str, start: str, end: str) -> str:
+        s = text.find(start)
+        e = text.find(end)
+        if s == -1 or e == -1:
+            return ""
+        return text[s + len(start):e].strip()
+
+    return {
+        "spike_summary":       _extract(response_text, "---SPIKE_START---",       "---SPIKE_END---"),
+        "sentiment_summary":   _extract(response_text, "---SENTIMENT_START---",   "---SENTIMENT_END---"),
+        "opportunity_summary": _extract(response_text, "---OPPORTUNITY_START---", "---OPPORTUNITY_END---"),
+    }
+
+
+# ============================================================
+# 추가될 프롬프트 (미구현)
 # ============================================================
 
 # def build_sentiment_prompt(text: str) -> str:


### PR DESCRIPTION
## ✅ 작업 내용
- (예: Kafka consumer 메시지 파싱 로직 리팩토링)
- (예: LangGraph 상태 전이 조건 수정)
- Kafka 메시지를 키워드별로 15초 윈도우 동안 버퍼링 후 배치 분석 처리
- Slack 중복 전송 수정 및 LLM 설명 포맷 개선
- 프롬프트 및 nodes 출력 포맷 수정
- asyncio.run() 방식으로 이벤트 루프 통일
- main 쪽 `msg.keyword` 버그 → `keyword`로 수정
- 키워드 버퍼링 로직 쪽 확인 부탁드립니다.. 
---

## 🔗 관련 이슈
- 연결된 이슈: #이슈번호 (예: closes #18)

---

## 💬 특이사항
- (예: 프롬프트 성능 향상을 위해 lexicon 일부 수정했음 → 민서 확인 필요)
