### PR TITLE
chore: GCP 배포 환경 수정

### DIFF
--- a/Dockerfile.consumer
+++ b/Dockerfile.consumer
@@ -1,8 +1,8 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.dashboard
+++ b/Dockerfile.dashboard
@@ -1,8 +1,8 @@
-FROM python:3.11-slim
+FROM python:3.11-slim-bookworm
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,9 +6,9 @@ set -euo pipefail
 # ============================================================
 # 설정
 # ============================================================
-PROJECT_ID="33643663123"       # GCP 프로젝트 ID
+PROJECT_ID="dolpin-aiders"       # GCP 프로젝트 ID
 REGION="asia-northeast3"               # 서울 리전 (Kafka 서버와 동일)
-GCS_BUCKET="dolpin-aiders"     # GCS 버킷 이름 (결과 저장용)
+GCS_BUCKET="dolpin-aiders-results"     # GCS 버킷 이름 (결과 저장용)
 
 REPO="dolpin"
 REGISTRY="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}"


### PR DESCRIPTION
## ✅ 작업 내용

- Dockerfile 베이스 이미지 python:3.11-slim → python:3.11-slim-bookworm (Debian 12)
- apt-get upgrade 추가로 OS 패키지 취약점 감소
- deploy.sh PROJECT_ID  수정


---

## 🔗 관련 이슈


---

## 💬 특이사항

