### PR TITLE
chore: Add collector Cloud Run job deployment

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,16 @@
+.git/
+.github/
+.venv/
+__pycache__/
+.pytest_cache/
+*.pyc
+*.pyo
+*.egg-info/
+dist/
+build/
+tests/
+.env
+*.log
+*.jsonl
+ai_pipeline_diagram.png
+generate_diagram.py

--- a/Dockerfile.collector
+++ b/Dockerfile.collector
@@ -1,0 +1,26 @@
+FROM python:3.11-slim-bookworm
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    nodejs \
+    npm \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+RUN python -m playwright install --with-deps chromium
+
+COPY src/server/x-v2-server/package*.json ./src/server/x-v2-server/
+WORKDIR /app/src/server/x-v2-server
+RUN npm ci
+
+COPY src/server/x-v2-server ./
+RUN npm run build
+
+WORKDIR /app
+COPY . .
+
+CMD ["python", "-m", "src.pipeline.collector"]

--- a/deploy_collector.sh
+++ b/deploy_collector.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-dolpin-aiders}"
+REGION="${REGION:-asia-northeast3}"
+REPO="${REPO:-dolpin}"
+JOB_NAME="${JOB_NAME:-dolpin-collector}"
+SCHEDULER_NAME="${SCHEDULER_NAME:-dolpin-collector-every-30m}"
+SCHEDULE="${SCHEDULE:-*/30 * * * *}"
+TIME_ZONE="${TIME_ZONE:-Asia/Seoul}"
+KEYWORD="${KEYWORD:-}"
+
+if [[ -z "${KEYWORD}" ]]; then
+  echo "ERROR: Set KEYWORD before running this script."
+  echo "Example: KEYWORD=\"아이브\" ./deploy_collector.sh"
+  exit 1
+fi
+
+REGISTRY="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}"
+IMAGE_COLLECTOR="${REGISTRY}/collector:latest"
+SA_NAME="${SA_NAME:-dolpin-sa}"
+SA_EMAIL="${SA_EMAIL:-${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com}"
+
+COMMON_SECRETS="\
+KAFKA_BOOTSTRAP_SERVERS=dolpin_KAFKA_BOOTSTRAP_SERVERS:latest,\
+KAFKA_API_KEY=dolpin_KAFKA_API_KEY:latest,\
+KAFKA_API_SECRET=dolpin_KAFKA_API_SECRET:latest,\
+KAFKA_TOPIC=dolpin_KAFKA_TOPIC:latest,\
+TWITTER_BEARER_TOKEN=dolpin_TWITTER_BEARER_TOKEN:latest,\
+TWITTER_API_KEY=dolpin_TWITTER_API_KEY:latest,\
+TWITTER_API_KEY_SECRET=dolpin_TWITTER_API_KEY_SECRET:latest,\
+TWITTER_ACCESS_TOKEN=dolpin_TWITTER_ACCESS_TOKEN:latest,\
+TWITTER_ACCESS_TOKEN_SECRET=dolpin_TWITTER_ACCESS_TOKEN_SECRET:latest,\
+INSTIZ_ID=dolpin_INSTIZ_ID:latest,\
+INSTIZ_PW=dolpin_INSTIZ_PW:latest,\
+MODE=dolpin_MODE:latest"
+
+echo "=== Enable required APIs ==="
+gcloud services enable \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  cloudscheduler.googleapis.com \
+  --project="${PROJECT_ID}"
+
+echo "=== Build and push collector image ==="
+docker build -f Dockerfile.collector -t "${IMAGE_COLLECTOR}" .
+docker push "${IMAGE_COLLECTOR}"
+
+echo "=== Create or update Cloud Run job ==="
+if gcloud run jobs describe "${JOB_NAME}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud run jobs update "${JOB_NAME}" \
+    --image="${IMAGE_COLLECTOR}" \
+    --region="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --service-account="${SA_EMAIL}" \
+    --command=python \
+    --args=-m,src.pipeline.collector,"${KEYWORD}" \
+    --set-secrets="${COMMON_SECRETS}" \
+    --memory=2Gi \
+    --cpu=1 \
+    --task-timeout=900s \
+    --max-retries=1
+else
+  gcloud run jobs create "${JOB_NAME}" \
+    --image="${IMAGE_COLLECTOR}" \
+    --region="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --service-account="${SA_EMAIL}" \
+    --command=python \
+    --args=-m,src.pipeline.collector,"${KEYWORD}" \
+    --set-secrets="${COMMON_SECRETS}" \
+    --memory=2Gi \
+    --cpu=1 \
+    --task-timeout=900s \
+    --max-retries=1
+fi
+
+echo "=== Grant scheduler permission to execute the job ==="
+gcloud run jobs add-iam-policy-binding "${JOB_NAME}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/run.invoker" \
+  --quiet
+
+echo "=== Create or update scheduler job ==="
+RUN_URI="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${JOB_NAME}:run"
+
+if gcloud scheduler jobs describe "${SCHEDULER_NAME}" \
+  --location="${REGION}" \
+  --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud scheduler jobs update http "${SCHEDULER_NAME}" \
+    --location="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --schedule="${SCHEDULE}" \
+    --time-zone="${TIME_ZONE}" \
+    --uri="${RUN_URI}" \
+    --http-method=POST \
+    --oauth-service-account-email="${SA_EMAIL}"
+else
+  gcloud scheduler jobs create http "${SCHEDULER_NAME}" \
+    --location="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --schedule="${SCHEDULE}" \
+    --time-zone="${TIME_ZONE}" \
+    --uri="${RUN_URI}" \
+    --http-method=POST \
+    --oauth-service-account-email="${SA_EMAIL}"
+fi
+
+echo ""
+echo "Collector job: ${JOB_NAME}"
+echo "Image: ${IMAGE_COLLECTOR}"
+echo "Keyword: ${KEYWORD}"
+echo "Schedule: ${SCHEDULE} (${TIME_ZONE})"
+echo ""
+echo "Test manually:"
+echo "gcloud run jobs execute ${JOB_NAME} --region=${REGION} --project=${PROJECT_ID} --wait"


### PR DESCRIPTION
## ✅ 작업 내용

- Cloud Run Jobs용 collector 전용 Dockerfile 추가
- Collector 이미지를 빌드/푸시하고, Cloud Run Job을 생성 또는 업데이트하며, Cloud Scheduler를 설정하는 배포 스크립트 추가
- Cloud Build가 .gitignore 규칙을 그대로 상속받아 custom_lexicon.csv 같은 필수 런타임 CSV 파일을 제외하지 않도록 .gcloudignore 추가
---

## 🔗 관련 이슈
- 연결된 이슈: #이슈번호 (예: closes #18)

---

## 💬 특이사항
- 배포 시 collector 키워드는 필수입니다:
`KEYWORD="NCT WISH" ./deploy_collector.sh`
- Scheduler는 기본적으로 Asia/Seoul 기준 30분마다 실행되도록 설정되어 있습니다.
- Secret 값은 커밋하지 않았으며, 스크립트는 기존 Secret Manager의 secret 이름만 참조합니다.
