### PR TITLE
fix: GCS 저장을 Slack 전송 전에 실행하고 버킷 이름 공백 제거

### DIFF
--- a/src/dolpin_langgraph/nodes.py
+++ b/src/dolpin_langgraph/nodes.py
@@ -855,6 +855,13 @@ def exec_brief_node(state: AnalysisState) -> AnalysisState:
 
         _update_node_insight(state, "exec_brief", "generated")
 
+        try:
+            from src.pipeline.result_store import save_result
+            save_result(state)
+            logger.info("GCS 저장 완료 (Slack 전송 전)")
+        except Exception as e:
+            logger.warning(f"GCS 저장 실패 (Slack 전송은 계속 진행): {e}")
+
         bot_token = os.getenv("SLACK_BOT_TOKEN")
         channel_id = os.getenv("SLACK_CHANNEL_ID")
         if bot_token and channel_id:

--- a/src/pipeline/result_store.py
+++ b/src/pipeline/result_store.py
@@ -16,7 +16,8 @@ _BLOB_NAME = "dolpin/latest_result.json"
 
 
 def _bucket_name() -> Optional[str]:
-    return os.getenv("GCS_BUCKET_NAME")
+    name = os.getenv("GCS_BUCKET_NAME")
+    return name.strip() if name else None
 
 
 def save_result(result: dict) -> None:


### PR DESCRIPTION
- exec_brief_node에서 Slack 전송 전에 save_result 호출하여 대시보드 버튼 클릭 시 데이터 보장
- result_store._bucket_name()에 .strip() 추가로 Secret Manager 개행문자 문제 해결

## ✅ 작업 내용
- (예: Kafka consumer 메시지 파싱 로직 리팩토링)
- (예: LangGraph 상태 전이 조건 수정)

---

## 🔗 관련 이슈
- 연결된 이슈: #이슈번호 (예: closes #18)

---

## 💬 특이사항
- (예: 프롬프트 성능 향상을 위해 lexicon 일부 수정했음 → 민서 확인 필요)
