### PR TITLE
feat: Custom Metric Autoscaling 구현

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,9 +8,11 @@ __pycache__/
 *.egg-info/
 dist/
 build/
+node_modules/
 tests/
 .pytest_cache/
 *.log
 *.jsonl
 ai_pipeline_diagram.png
 generate_diagram.py
+load_test/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/Dockerfile.scaler
+++ b/Dockerfile.scaler
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir \
+    google-cloud-monitoring \
+    google-cloud-run \
+    python-dotenv
+
+COPY src/scaler.py ./src/scaler.py
+
+CMD ["python", "-m", "src.scaler"]

--- a/deploy.sh
+++ b/deploy.sh
@@ -25,6 +25,7 @@ gcloud services enable \
   secretmanager.googleapis.com \
   storage.googleapis.com \
   cloudbuild.googleapis.com \
+  monitoring.googleapis.com \
   --project="${PROJECT_ID}"
 
 # ============================================================
@@ -146,7 +147,7 @@ gcloud run deploy dolpin-dashboard \
   --project="${PROJECT_ID}" \
   --service-account="${SA_EMAIL}" \
   --set-secrets="${DASHBOARD_SECRETS}" \
-  --set-env-vars="GCP_PROJECT=${PROJECT_ID}" \
+  --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID}" \
   --memory=2Gi \
   --cpu=1 \
   --port=8080 \
@@ -163,12 +164,12 @@ gcloud run deploy dolpin-consumer \
   --project="${PROJECT_ID}" \
   --service-account="${SA_EMAIL}" \
   --set-secrets="${CONSUMER_SECRETS}" \
-  --set-env-vars="GCP_PROJECT=${PROJECT_ID}" \
+  --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID}" \
   --memory=4Gi \
   --cpu=2 \
   --port=8080 \
   --min-instances=1 \
-  --max-instances=1 \
+  --max-instances=5 \
   --no-allow-unauthenticated \
   --quiet
 

--- a/deploy_scaler.sh
+++ b/deploy_scaler.sh
@@ -24,17 +24,20 @@ gcloud services enable \
   run.googleapis.com \
   cloudscheduler.googleapis.com \
   monitoring.googleapis.com \
+  cloudbuild.googleapis.com \
   --project="${PROJECT_ID}"
 
 # ============================================================
 # 2. 서비스 계정에 Cloud Run 관리 권한 부여
 #    (스케일러가 dolpin-consumer의 min-instances를 수정하므로 필요)
 # ============================================================
-echo "=== Grant Cloud Run Admin role to SA ==="
-gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
-  --member="serviceAccount:${SA_EMAIL}" \
-  --role="roles/run.admin" \
-  --quiet
+echo "=== Grant required roles to SA ==="
+for ROLE in roles/run.admin roles/monitoring.viewer; do
+  gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="${ROLE}" \
+    --quiet
+done
 
 # ============================================================
 # 3. 이미지 빌드 & 푸시 (Cloud Build)

--- a/deploy_scaler.sh
+++ b/deploy_scaler.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# dolpin-scaler Cloud Run Job + Cloud Scheduler 배포
+# 실행 전: gcloud auth login && gcloud auth configure-docker asia-northeast3-docker.pkg.dev
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-dolpin-aiders}"
+REGION="${REGION:-asia-northeast3}"
+REPO="${REPO:-dolpin}"
+JOB_NAME="${JOB_NAME:-dolpin-scaler}"
+SCHEDULER_NAME="${SCHEDULER_NAME:-dolpin-scaler-every-5m}"
+SCHEDULE="${SCHEDULE:-*/5 * * * *}"
+TIME_ZONE="${TIME_ZONE:-Asia/Seoul}"
+
+REGISTRY="${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}"
+IMAGE_SCALER="${REGISTRY}/scaler:latest"
+SA_NAME="${SA_NAME:-dolpin-sa}"
+SA_EMAIL="${SA_EMAIL:-${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com}"
+
+# ============================================================
+# 1. 필요 API 활성화
+# ============================================================
+echo "=== Enable APIs ==="
+gcloud services enable \
+  run.googleapis.com \
+  cloudscheduler.googleapis.com \
+  monitoring.googleapis.com \
+  --project="${PROJECT_ID}"
+
+# ============================================================
+# 2. 서비스 계정에 Cloud Run 관리 권한 부여
+#    (스케일러가 dolpin-consumer의 min-instances를 수정하므로 필요)
+# ============================================================
+echo "=== Grant Cloud Run Admin role to SA ==="
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/run.admin" \
+  --quiet
+
+# ============================================================
+# 3. 이미지 빌드 & 푸시 (Cloud Build)
+# ============================================================
+echo "=== Build and push scaler image ==="
+cp Dockerfile.scaler Dockerfile
+cleanup() { rm -f Dockerfile; }
+trap cleanup EXIT
+gcloud builds submit . --tag="${IMAGE_SCALER}" --project="${PROJECT_ID}"
+
+# ============================================================
+# 4. Cloud Run Job 생성 또는 업데이트
+# ============================================================
+echo "=== Create or update Cloud Run job ==="
+
+JOB_FLAGS=(
+  --image="${IMAGE_SCALER}"
+  --region="${REGION}"
+  --project="${PROJECT_ID}"
+  --service-account="${SA_EMAIL}"
+  --set-env-vars="GCP_PROJECT_ID=${PROJECT_ID},REGION=${REGION},CONSUMER_SERVICE_NAME=dolpin-consumer"
+  --memory=512Mi
+  --cpu=1
+  --task-timeout=120s
+  --max-retries=1
+)
+
+if gcloud run jobs describe "${JOB_NAME}" \
+    --region="${REGION}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud run jobs update "${JOB_NAME}" "${JOB_FLAGS[@]}"
+else
+  gcloud run jobs create "${JOB_NAME}" "${JOB_FLAGS[@]}"
+fi
+
+# ============================================================
+# 5. Cloud Scheduler가 Job을 실행할 수 있도록 IAM 부여
+# ============================================================
+echo "=== Grant scheduler invoker permission ==="
+gcloud run jobs add-iam-policy-binding "${JOB_NAME}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}" \
+  --member="serviceAccount:${SA_EMAIL}" \
+  --role="roles/run.invoker" \
+  --quiet
+
+# ============================================================
+# 6. Cloud Scheduler 생성 또는 업데이트 (5분 주기)
+# ============================================================
+echo "=== Create or update Cloud Scheduler ==="
+RUN_URI="https://run.googleapis.com/v2/projects/${PROJECT_ID}/locations/${REGION}/jobs/${JOB_NAME}:run"
+
+if gcloud scheduler jobs describe "${SCHEDULER_NAME}" \
+    --location="${REGION}" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+  gcloud scheduler jobs update http "${SCHEDULER_NAME}" \
+    --location="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --schedule="${SCHEDULE}" \
+    --time-zone="${TIME_ZONE}" \
+    --uri="${RUN_URI}" \
+    --http-method=POST \
+    --oauth-service-account-email="${SA_EMAIL}"
+else
+  gcloud scheduler jobs create http "${SCHEDULER_NAME}" \
+    --location="${REGION}" \
+    --project="${PROJECT_ID}" \
+    --schedule="${SCHEDULE}" \
+    --time-zone="${TIME_ZONE}" \
+    --uri="${RUN_URI}" \
+    --http-method=POST \
+    --oauth-service-account-email="${SA_EMAIL}"
+fi
+
+# ============================================================
+# 완료
+# ============================================================
+echo ""
+echo "=== Scaler 배포 완료 ==="
+echo "Job:      ${JOB_NAME}"
+echo "Image:    ${IMAGE_SCALER}"
+echo "Schedule: ${SCHEDULE} (${TIME_ZONE})"
+echo ""
+echo "수동 실행 테스트:"
+echo "  gcloud run jobs execute ${JOB_NAME} --region=${REGION} --project=${PROJECT_ID} --wait"
+echo ""
+echo "로그 확인:"
+echo "  gcloud logging read 'resource.type=cloud_run_job AND resource.labels.job_name=${JOB_NAME}' --project=${PROJECT_ID} --limit=50"

--- a/load_test/locustfile.py
+++ b/load_test/locustfile.py
@@ -1,0 +1,121 @@
+"""
+Dolpin 서비스 부하 테스트 (Locust)
+
+설치:
+  pip install locust
+
+실행 예시:
+  # 대시보드만 (비인증)
+  locust -f load_test/locustfile.py --host=<DASHBOARD_URL> \\
+    --users 50 --spawn-rate 5 --run-time 3m --headless
+
+  # Consumer 헬스체크 포함 (GCP 인증 필요)
+  export CONSUMER_URL=<CONSUMER_URL>
+  export GCP_TOKEN=$(gcloud auth print-identity-token --audiences="${CONSUMER_URL}")
+  locust -f load_test/locustfile.py --host=<DASHBOARD_URL> \\
+    --users 50 --spawn-rate 5 --run-time 3m --headless
+
+스케일링 관찰 방법:
+  # 테스트 실행 중 별도 터미널에서 min-instances 변화 모니터링
+  watch -n 10 "gcloud run services describe dolpin-consumer \\
+    --region=asia-northeast3 --project=dolpin-aiders \\
+    --format='value(spec.template.metadata.annotations)'"
+"""
+
+import os
+import subprocess
+
+from locust import HttpUser, between, events, task
+
+CONSUMER_URL = os.getenv("CONSUMER_URL", "").rstrip("/")
+GCP_TOKEN = os.getenv("GCP_TOKEN", "")
+
+
+def _resolve_token() -> str:
+    """GCP_TOKEN 환경변수 없으면 gcloud로 자동 발급."""
+    if GCP_TOKEN:
+        return GCP_TOKEN
+    if not CONSUMER_URL:
+        return ""
+    try:
+        result = subprocess.run(
+            ["gcloud", "auth", "print-identity-token", f"--audiences={CONSUMER_URL}"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except Exception:
+        return ""
+
+
+@events.init.add_listener
+def on_init(environment, **kwargs):
+    print("\n" + "=" * 60)
+    print("Dolpin Load Test")
+    print(f"  Dashboard  : {environment.host}")
+    print(f"  Consumer   : {CONSUMER_URL or '(skipped — CONSUMER_URL not set)'}")
+    print("=" * 60 + "\n")
+
+
+# ──────────────────────────────────────────────────────────
+# 1. Dashboard 부하 (공개 접근, 전체 유저의 75%)
+# ──────────────────────────────────────────────────────────
+class DashboardUser(HttpUser):
+    """Streamlit 대시보드 엔드포인트 부하 테스트."""
+    wait_time = between(1, 3)
+    weight = 3
+
+    @task(4)
+    def health(self):
+        # Streamlit 헬스 엔드포인트
+        with self.client.get("/_stcore/health", catch_response=True, name="dashboard/health") as r:
+            if r.status_code == 200:
+                r.success()
+            else:
+                r.failure(f"health {r.status_code}")
+
+    @task(1)
+    def main_page(self):
+        with self.client.get("/", catch_response=True, name="dashboard/") as r:
+            if r.status_code in (200, 302):
+                r.success()
+            else:
+                r.failure(f"main {r.status_code}")
+
+
+# ──────────────────────────────────────────────────────────
+# 2. Consumer 헬스체크 (IAM 인증, 전체 유저의 25%)
+#    → 실제 Kafka 파이프라인 인스턴스 동시성 테스트
+# ──────────────────────────────────────────────────────────
+class ConsumerUser(HttpUser):
+    """Consumer Cloud Run Service 헬스체크 동시성 테스트."""
+    wait_time = between(2, 5)
+    weight = 1
+    # host는 --host 인자 대신 CONSUMER_URL로 재정의
+    host = CONSUMER_URL or "http://localhost:8080"
+
+    def on_start(self):
+        self._token = _resolve_token()
+        if not self._token:
+            self._skip = True
+            return
+        self._skip = False
+        self._headers = {"Authorization": f"Bearer {self._token}"}
+
+    @task
+    def health(self):
+        if getattr(self, "_skip", True):
+            return  # Consumer URL 없으면 스킵
+        with self.client.get(
+            "/",
+            headers=self._headers,
+            catch_response=True,
+            name="consumer/health",
+        ) as r:
+            if r.status_code == 200:
+                r.success()
+            elif r.status_code == 403:
+                r.failure("403 — GCP 토큰 만료 또는 권한 없음")
+            else:
+                r.failure(f"consumer health {r.status_code}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,9 @@ slack_sdk>=3.19.0
 mcp>=0.5.0
 playwright>=1.40.0
 pytrends>=4.9.2
-google-cloud-storage  
+urllib3<2                 # pytrends가 urllib3 2.x의 method_whitelist 제거에 미대응
+google-cloud-storage
+google-cloud-monitoring
 
 # Data Streaming
-confluent-kafka>=2.0.0  
+confluent-kafka>=2.0.0

--- a/src/scaler.py
+++ b/src/scaler.py
@@ -37,7 +37,13 @@ MAX_INSTANCES = 5
 
 
 def _get_max_score(monitoring_client: monitoring_v3.MetricServiceClient) -> float:
-    """최근 LOOKBACK_SECONDS 동안의 actionability_score 최댓값 반환."""
+    """최근 LOOKBACK_SECONDS 동안의 actionability_score 최댓값 반환.
+
+    메트릭이 아직 한 번도 전송된 적 없으면 GCP가 404를 반환하므로
+    해당 케이스는 데이터 없음(0.0)으로 처리한다.
+    """
+    from google.api_core.exceptions import NotFound
+
     now = time.time()
     interval = monitoring_v3.TimeInterval(
         {
@@ -45,19 +51,23 @@ def _get_max_score(monitoring_client: monitoring_v3.MetricServiceClient) -> floa
             "start_time": {"seconds": int(now - LOOKBACK_SECONDS)},
         }
     )
-    results = monitoring_client.list_time_series(
-        request={
-            "name": f"projects/{PROJECT_ID}",
-            "filter": f'metric.type="{METRIC_TYPE}"',
-            "interval": interval,
-            "view": monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
-        }
-    )
-    max_score = 0.0
-    for ts in results:
-        for point in ts.points:
-            max_score = max(max_score, point.value.double_value)
-    return round(max_score, 4)
+    try:
+        results = monitoring_client.list_time_series(
+            request={
+                "name": f"projects/{PROJECT_ID}",
+                "filter": f'metric.type="{METRIC_TYPE}"',
+                "interval": interval,
+                "view": monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
+            }
+        )
+        max_score = 0.0
+        for ts in results:
+            for point in ts.points:
+                max_score = max(max_score, point.value.double_value)
+        return round(max_score, 4)
+    except NotFound:
+        logger.info("메트릭 없음 (아직 전송된 데이터 없음) → score=0.0으로 처리")
+        return 0.0
 
 
 def _target_min_instances(score: float) -> int:

--- a/src/scaler.py
+++ b/src/scaler.py
@@ -1,0 +1,118 @@
+"""
+Custom metric 기반 Cloud Run 자동 스케일러.
+Cloud Monitoring에서 actionability_score를 읽어
+dolpin-consumer의 min-instances를 동적으로 조절합니다.
+
+실행 주기: Cloud Scheduler가 5분마다 Cloud Run Job으로 실행.
+
+스케일링 정책:
+  actionability_score >= 0.6  →  min_instances = 3  (고위험 스파이크)
+  actionability_score >= 0.3  →  min_instances = 2  (중위험)
+  actionability_score <  0.3  →  min_instances = 1  (기본)
+"""
+
+import logging
+import os
+import time
+
+from google.cloud import monitoring_v3, run_v2
+from google.protobuf import field_mask_pb2
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+PROJECT_ID = os.environ["GCP_PROJECT_ID"]
+REGION = os.getenv("REGION", "asia-northeast3")
+SERVICE_NAME = os.getenv("CONSUMER_SERVICE_NAME", "dolpin-consumer")
+METRIC_TYPE = "custom.googleapis.com/dolpin/analysis/actionability_score"
+LOOKBACK_SECONDS = 300  # 최근 5분간 최댓값 기준
+
+# (임계값, min_instances) — 높은 쪽부터 체크
+SCALE_TIERS: list[tuple[float, int]] = [
+    (0.6, 3),
+    (0.3, 2),
+    (0.0, 1),
+]
+MAX_INSTANCES = 5
+
+
+def _get_max_score(monitoring_client: monitoring_v3.MetricServiceClient) -> float:
+    """최근 LOOKBACK_SECONDS 동안의 actionability_score 최댓값 반환."""
+    now = time.time()
+    interval = monitoring_v3.TimeInterval(
+        {
+            "end_time": {"seconds": int(now)},
+            "start_time": {"seconds": int(now - LOOKBACK_SECONDS)},
+        }
+    )
+    results = monitoring_client.list_time_series(
+        request={
+            "name": f"projects/{PROJECT_ID}",
+            "filter": f'metric.type="{METRIC_TYPE}"',
+            "interval": interval,
+            "view": monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
+        }
+    )
+    max_score = 0.0
+    for ts in results:
+        for point in ts.points:
+            max_score = max(max_score, point.value.double_value)
+    return round(max_score, 4)
+
+
+def _target_min_instances(score: float) -> int:
+    for threshold, instances in SCALE_TIERS:
+        if score >= threshold:
+            return instances
+    return 1
+
+
+def _get_current_min(run_client: run_v2.ServicesClient, service_path: str) -> int:
+    service = run_client.get_service(name=service_path)
+    return service.template.scaling.min_instance_count
+
+
+def _update_scaling(
+    run_client: run_v2.ServicesClient,
+    service_path: str,
+    min_instances: int,
+) -> None:
+    service = run_client.get_service(name=service_path)
+    service.template.scaling.min_instance_count = min_instances
+    service.template.scaling.max_instance_count = MAX_INSTANCES
+    run_client.update_service(
+        request={
+            "service": service,
+            "update_mask": field_mask_pb2.FieldMask(paths=["template.scaling"]),
+        }
+    ).result()  # 완료까지 블로킹
+
+
+def main() -> None:
+    monitoring_client = monitoring_v3.MetricServiceClient()
+    run_client = run_v2.ServicesClient()
+    service_path = (
+        f"projects/{PROJECT_ID}/locations/{REGION}/services/{SERVICE_NAME}"
+    )
+
+    score = _get_max_score(monitoring_client)
+    target = _target_min_instances(score)
+    current = _get_current_min(run_client, service_path)
+
+    logger.info(
+        "actionability_score=%.4f  →  target min_instances=%d  (current=%d)",
+        score,
+        target,
+        current,
+    )
+
+    if target != current:
+        logger.info("스케일 조정: min_instances %d → %d", current, target)
+        _update_scaling(run_client, service_path, target)
+        logger.info("완료")
+    else:
+        logger.info("변경 없음 (min_instances=%d 유지)", current)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## ✅ 작업 내용
- Consumer max-instances=1 → 5 로 변경, 실제 스케일링 가능하도록 수정
- scaler.py 신규 작성: Cloud Monitoring에서 actionability_score 조회 후 dolpin-consumer min-instances 자동 조절
---


## 💬 특이사항
- 스케일링 정책: actionability_score ≥ 0.6 → min 3개 / ≥ 0.3 → min 2개 / 기본 → 1개
- 메트릭이 아직 쌓이기 전(첫 실행)에 GCP API가 404를 던지는 이슈 있어서 예외 처리 추가함
- GCP 재배포는 Cloud Shell에서 직접 진행 완료
